### PR TITLE
FAQ on why zkSync does not prove all batches on testnet

### DIFF
--- a/docs/dev/troubleshooting/faq.md
+++ b/docs/dev/troubleshooting/faq.md
@@ -193,11 +193,11 @@ Yes, the bridge is two-way. You can withdraw your funds back to Ethereum. The wi
 
 Sometimes, the team working on zkSync will initiate a regenesis on testnet - a restart of the blockchain which will introduce upgrades and return the state to the initial point.
 
-## Why does zkSync Era not prove all batches on testnet?
+## Proof sampling on testnet
 
-On zkSync Era testnet and mainnet, blocks are batched together and verified by the ZK prover. On mainnet, we prove all batches. On testnet we prove fewer batches to avoid wasting expensive GPU resources that we could use for mainnet development and security.
+zkSync Era testnet is experiencing immense demand, but its permissionless nature leaves our developer infrastructure vulnerable to potential DoS attack vectors. Generating ZK proofs inherently incurs costs, and a determined attacker could exploit this by submitting a massive number of transactions, resulting in significant expenses for us. As we currently lack a more effective method for rationing resources, we have opted to prove a random subset of batches on the testnet – the subset fluctuates with demand but maintains a high minimal threshold. This approach ensures the detection of errors probabilistically while conserving valuable GPU resources.
 
-Doing this is also much greener than proving every single batch on testnet.
+This resource optimization not only supports a more efficient allocation of resources but also promotes a more environmentally-friendly process compared to proving every batch on the testnet.
 
-As we increase our prover performance and efficiency, we will enable proofs for all batches on testnet.
+Moving forward, we aim to develop better mechanisms to prevent Sybil attacks on our infrastructure, with the ultimate goal of enabling the proof of all batches on the testnet.
 

--- a/docs/dev/troubleshooting/faq.md
+++ b/docs/dev/troubleshooting/faq.md
@@ -192,3 +192,12 @@ Yes, the bridge is two-way. You can withdraw your funds back to Ethereum. The wi
 ## What is a testnet ReGenesis?
 
 Sometimes, the team working on zkSync will initiate a regenesis on testnet - a restart of the blockchain which will introduce upgrades and return the state to the initial point.
+
+## Why does zkSync Era not prove all batches on testnet?
+
+On zkSync Era testnet and mainnet, blocks are batched together and verified by the ZK prover. On mainnet, we prove all batches. On testnet we prove fewer batches to avoid wasting expensive GPU resources that we could use for mainnet development and security.
+
+Doing this is also much greener than proving every single batch on testnet.
+
+As we increase our prover performance and efficiency, we will enable proofs for all batches on testnet.
+


### PR DESCRIPTION
Stated why zkSync Era does not prove all batches on testnet on the FAQ page.