### PR TITLE
change go-sdk: go-ethereum/rpc to common

### DIFF
--- a/docs/api/go/getting-started.md
+++ b/docs/api/go/getting-started.md
@@ -76,7 +76,7 @@ ethereumProvider, err := w.CreateEthereumProvider(ethRpc)
 package main
 
 import (
-    "github.com/ethereum/go-ethereum/rpc"
+    "github.com/ethereum/go-ethereum/common"
     "github.com/zksync-sdk/zksync2-go"
 )
 
@@ -103,7 +103,7 @@ func main() {
 package main
 
 import (
-    "github.com/ethereum/go-ethereum/rpc"
+    "github.com/ethereum/go-ethereum/common"
     "github.com/zksync-sdk/zksync2-go"
 )
 
@@ -161,7 +161,7 @@ You can access the contract deployer interface as follows:
     package main
 
 import (
-    "github.com/ethereum/go-ethereum/rpc"
+    "github.com/ethereum/go-ethereum/common"
     "github.com/zksync-sdk/zksync2-go"
 )
 
@@ -199,7 +199,7 @@ Example encoding the calldata:
 package main
 
 import (
-    "github.com/ethereum/go-ethereum/rpc"
+    "github.com/ethereum/go-ethereum/common"
     "github.com/zksync-sdk/zksync2-go"
 )
 


### PR DESCRIPTION
I was going through the go-sdk docs for zkSync Era, and found out that the import parts of the go scripts could need a change. I saw that some scripts were importing go-ethereum/rpc although it was supposed to import go-ethereum/common. In the general script, rpc is needed, but since the docs were organized according to single functions (deposit, withdraw etc.), not importing the necesssary packages could confuse developers. 

I changed the go-ethereum/rpc imports to go-ethereum/common wherever they were supposed to be imported.