### PR TITLE
Fix dead links

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -42,13 +42,6 @@ If this is your first time using zkSync, we recommend that you kick off at the b
 - [Vyper](compiler-toolchain/vyper.md) - Learn about the Vyper support.
 - [LLVM Framework](compiler-toolchain/llvm.md) - Learn about the LLVM framework.
 
-### Compiler Toolchain
-
-- [Overview](compiler-toolchain/overview.md) - Learn about our compiler toolchain.
-- [Solidity](compiler-toolchain/solidity.md) - Learn about the Solidity support.
-- [Vyper](compiler-toolchain/vyper.md) - Learn about the Vyper support.
-- [LLVM Framework](compiler-toolchain/llvm.md) - Learn about the LLVM framework.
-
 ### Tutorials
 
 - [Cross-chain governance](./tutorials/cross-chain-tutorial.md) - Learn how to use L1 to L2 contract interaction.

--- a/docs/dev/compiler-toolchain/overview.md
+++ b/docs/dev/compiler-toolchain/overview.md
@@ -52,15 +52,15 @@ easier to maintain outside of the framework.
 
 ## Hardhat Plugins
 
-We recommend using our IR compilers via [their corresponding Hardhat plugins](../../../api/hardhat/plugins.md).
+We recommend using our IR compilers via [their corresponding Hardhat plugins](../../api/hardhat/plugins.md).
 Add these plugins to the Hardhat's config file to compile new projects or migrate
 existing ones to zkSync Era. For a lower-level approach, download our compiler binaries via the
 links above and use their CLI interfaces.
 
 **Learn more about how to install and configure these plugins in the links below:**
 
-- [hardhat-zksync-solc documentation](../../../api/hardhat/hardhat-zksync-solc.md)
-- [hardhat-zksync-vyper documentation](../../../api/hardhat/hardhat-zksync-vyper.md)
+- [hardhat-zksync-solc documentation](../../api/hardhat/hardhat-zksync-solc.md)
+- [hardhat-zksync-vyper documentation](../../api/hardhat/hardhat-zksync-vyper.md)
 
 ::: warning
 Using compilers running in Docker images - which are no longer released - is not recommended.

--- a/docs/dev/developer-guides/bridging/l1-l2.md
+++ b/docs/dev/developer-guides/bridging/l1-l2.md
@@ -65,7 +65,7 @@ The RPC function `zks_estimateGasL1ToL2` returns an estimate of how much gas is 
  If the sender is a smart contract, then during the L1->L2 the `msg.sender` address is aliased. Note that this is not done automatically during fee estimation, so it is your responsibility to use the zkSync [`aliasing utility`](#aliasing) to get the correct `from` address for the fee estimation.
 :::
 
-The function is wrapped in the [Provider](../../../api/js/providers.html#provider) class.
+The function is wrapped in the [Provider](../../../api/js/providers.md#provider) class.
 
 ```ts
 async estimateGasL1(transaction: utils.Deferrable<TransactionRequest>): Promise<BigNumber> {

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -10,7 +10,7 @@ To better understand this page, we recommend you first read up on the following 
 - Read about the [design](../developer-guides/aa.md) of the account abstraction protocol.
 - Read the [introduction to the system contracts](../developer-guides/system-contracts.md).
 - Read about [smart contract deployment](../building-on-zksync/contracts/contract-deployment.md) on zkSyn Era.
-- Read the [gas estimation for transaction](../developer-guides/transactions/fee-model.md#gas-estimation-during-transaction-for-custom-and-paymaster-accounts) guide.
+- Read the [gas estimation for transaction](../developer-guides/transactions/fee-model.md#gas-estimation-during-a-transaction-for-paymaster-and-custom-accounts) guide.
 - If you haven't, please refer to the first section of the [quickstart tutorial](../building-on-zksync/hello-world.md).
 
 

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -14,7 +14,7 @@ To better understand this page, we recommend you first read up on the following 
 - Read about the [design](../developer-guides/aa.md) of the account abstraction protocol.
 - Read the [introduction to the system contracts](../developer-guides/system-contracts.md).
 - Read about [smart contract deployment](../building-on-zksync/contracts/contract-deployment.md) on zkSyn Era.
-- Read the [gas estimation for transaction](../developer-guides/transactions/fee-model.md#gas-estimation-during-transaction-for-custom-and-paymaster-accounts) guide.
+- Read the [gas estimation for transaction](../developer-guides/transactions/fee-model.md#gas-estimation-during-a-transaction-for-paymaster-and-custom-accounts) guide.
 - If you haven't, please refer to the first section of the [quickstart tutorial](../building-on-zksync/hello-world.md).
 
 ## Installing dependencies


### PR DESCRIPTION
 Fix dead links and remove the repetitive section on the overview page.