### PR TITLE
upgrade zksolc verison

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -74,7 +74,7 @@ import "@matterlabs/hardhat-zksync-solc";
 
 module.exports = {
   zksolc: {
-    version: "1.3.5",
+    version: "1.3.8",
     compilerSource: "binary",
     settings: {},
   },


### PR DESCRIPTION
zksolc 1.3.5 cause error in macos where compile contract
================================
# yarn hardhat compile 

An unexpected error occurred:

Error: Command failed: /Users/pluto/Library/Caches/hardhat-nodejs/compilers-v2/zksolc/zksolc-v1.3.5 --standard-json    --solc /Users/pluto/Library/Caches/hardhat-nodejs/compilers-v2/macosx-amd64/solc-macosx-amd64-v0.8.17+commit.8df45f5f
unknown variant `metadata`, expected one of `abi`, `evm.methodIdentifiers`, `storageLayout`, `ast`, `irOptimized`, `evm.legacyAssembly` at line 1 column 647