### PR TITLE
compile with binaries

### DIFF
--- a/docs/api/hardhat/hardhat-zksync-solc.md
+++ b/docs/api/hardhat/hardhat-zksync-solc.md
@@ -38,7 +38,7 @@ zksolc: {
   settings: {
     compilerPath: "zksolc",  // optional. Ignored for compilerSource "docker". Can be used if compiler is located in a specific folder
     experimental: {
-      dockerImage: "matterlabs/zksolc", // Deprecated: used for compilerSource: "docker"
+      dockerImage: "matterlabs/zksolc", // Deprecated! use, compilerSource: "binary"
       tag: "latest"   // Deprecated: used for compilerSource: "docker"
     },
     libraries:{}, // optional. References to non-inlinable libraries

--- a/docs/dev/compiler-toolchain/overview.md
+++ b/docs/dev/compiler-toolchain/overview.md
@@ -76,4 +76,5 @@ existing ones to zkSync Era. For a lower-level approach, download our compiler b
 ::: warning
 - Using compilers running in Docker images is no longer supported.
 - Instead, use the `compilerSource: "binary"` in the Hardhat config file to use the compiler binary.
+- To compile with binaries, use `zksolc <contract>.sol --bin`.
 :::


### PR DESCRIPTION
- Added a comment that docker is deprecated and binary should be used in the `compilerSource` param.
- Also wrote a tip that `zksolc <contract>.sol --bin` command is to be used to compile with binaries.