### PR TITLE
Readme: Add quotes around `ethers` yarn install command

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -33,7 +33,7 @@ cd greeter-example
 
 ```sh
 yarn init -y
-yarn add -D typescript ts-node ethers@^5.7.2 zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
+yarn add -D typescript ts-node ethers@~5.7.2 zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
 ```
 
 :::info

--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -33,7 +33,7 @@ cd greeter-example
 
 ```sh
 yarn init -y
-yarn add -D typescript ts-node ethers@~5.7.2 zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
+yarn add -D typescript ts-node "ethers@^5.7.2" zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
 ```
 
 :::info


### PR DESCRIPTION
Added `"` quotes to fix install error in zsh

sample output of the error:
```
(base) makevoid@box zksync_project % yarn add -D ethers@^5.7.2
zsh: no matches found: ethers@^5.7.2
```