### PR TITLE
Remove unused 'Wallet ' import

### DIFF
--- a/docs/dev/tutorials/cross-chain-tutorial.md
+++ b/docs/dev/tutorials/cross-chain-tutorial.md
@@ -410,7 +410,7 @@ Now both contracts are deployed, we can create a script to retrieve the value of
 4. Create a `/L2-counter/scripts/display-value.ts` file and paste in the following code, adding the counter contract address:
 
 ```ts
-import { Contract, Provider, Wallet } from "zksync-web3";
+import { Contract, Provider } from "zksync-web3";
 
 // The address of the counter smart contract
 const COUNTER_ADDRESS = "<COUNTER CONTRACT ADDRESS>";


### PR DESCRIPTION
This PR removes the unused Wallet import from the zksync-web3 package in cross-chain-tutorial.md. The import statement for Wallet was found in the following code:
```
import { Contract, Provider, Wallet } from "zksync-web3";
```
However, Wallet is not used anywhere in the codebase. Therefore, it can be safely removed.