### PR TITLE
Update getMessageProof to getLogProof in L2-L1 doc

### DIFF
--- a/docs/dev/developer-guides/bridging/l2-l1.md
+++ b/docs/dev/developer-guides/bridging/l2-l1.md
@@ -124,12 +124,12 @@ The `proveL2MessageInclusion` function from the [Mailbox L1 contract](https://gi
 Here is a detailed description of the required parameters:
 
 - `_blockNumber` is the L1 batch number in which the L2 block was included. It can be retrieved using the `getBlock` method.
-- `_index` is the index of the L2 log in the block. It's returned as `id` by the `getLogProof` method of the `zksync-web3` API.
+- `_index` is the index of the L2 log in the block. It's returned as `id` by the [`zks_getL2ToL1LogProof`](../../../api/api.html#zks-getl2tol1logproof) method of the `zksync-web3` API.
 - `_message` is a parameter that contains the full information of the message sent. It should be an object containing:
   - `sender`: the address that sent the message from L2.
   - `data`: the message sent in bytes.
   - `txNumberInBlock`: the index of the transaction in the L2 block, which is returned as `transactionIndex` using `getTransaction`
-- `_proof` is a parameter that contains the Merkle proof of the message inclusion. It can be retrieved either from observing Ethereum or received from the `getLogProof` method of the `zksync-web3` API.
+- `_proof` is a parameter that contains the Merkle proof of the message inclusion. It can be retrieved either from observing Ethereum or received from the [`zks_getL2ToL1LogProof`](../../../api/api.html#zks-getl2tol1logproof) method of the `zksync-web3` API.
 
 ::: tip Important
 - The L2 block of your transaction must be verified (and hence the transaction finalized) before proving the inclusion in L1.

--- a/docs/dev/developer-guides/bridging/l2-l1.md
+++ b/docs/dev/developer-guides/bridging/l2-l1.md
@@ -124,17 +124,15 @@ The `proveL2MessageInclusion` function from the [Mailbox L1 contract](https://gi
 Here is a detailed description of the required parameters:
 
 - `_blockNumber` is the L1 batch number in which the L2 block was included. It can be retrieved using the `getBlock` method.
-- `_index` is the index of the L2 log in the block. It's returned as `id` by the `getMessageProof` method of the `zksync-web3` API.
+- `_index` is the index of the L2 log in the block. It's returned as `id` by the `getLogProof` method of the `zksync-web3` API.
 - `_message` is a parameter that contains the full information of the message sent. It should be an object containing:
   - `sender`: the address that sent the message from L2.
   - `data`: the message sent in bytes.
   - `txNumberInBlock`: the index of the transaction in the L2 block, which is returned as `transactionIndex` using `getTransaction`
-- `_proof` is a parameter that contains the Merkle proof of the message inclusion. It can be retrieved either from observing Ethereum or received from the `getMessageProof` method of the `zksync-web3` API.
+- `_proof` is a parameter that contains the Merkle proof of the message inclusion. It can be retrieved either from observing Ethereum or received from the `getLogProof` method of the `zksync-web3` API.
 
 ::: tip Important
-
-Note that the L2 block of your transaction must be verified (and hence the transaction finalized) before proving the inclusion in L1.
-
+- The L2 block of your transaction must be verified (and hence the transaction finalized) before proving the inclusion in L1.
 :::
 
 ### Example


### PR DESCRIPTION
- Ticket: https://linear.app/matterlabs/issue/DOC-145/update-l2-l1-page-to-not-use-getmessageproof-but-getlogproof-on-zksync
- Referring to Web3 API docs, I made two changes. Please check @StanislavBreadless / @vladbochok 