### PR TITLE
Hardhat quickstart changes

### DIFF
--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -12,7 +12,6 @@ zkSync Era has the following official plugins for Hardhat:
 
 ::: tip Additional plugins
 Learn more about [other plugins from the community](./other-plugins.md) that you can use with zkSync Era.
-
 :::
 
 To learn more about Hardhat itself, check out [its official documentation](https://hardhat.org/getting-started/).

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -41,7 +41,7 @@ To create a new project run the `create` task of the CLI passing a project name:
 ```sh
 zksync-cli create demo 
 ```
-This command will create a `demo` folder and clone a Hardhat template project inside it. The downloaded project is already configured and contains all the required plugins.
+This command creates a `demo` folder and clones a Hardhat template project inside it. The downloaded project is already configured and contains all the required plugins.
 
 ::: tip Migrating a project
 If you want to migrate an existing project, please check the [project migration guide](./migrating-to-zksync.md).

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -127,7 +127,7 @@ Note that the `artifacts-zk` and `cache-zk` folders  are already included in the
 
 :::
 
-In the `deploy` folder you'll find the `deploy-greeter.ts` script. This script uses the `Deployer` class from the `hardhat-zksync-deploy` package to deploy the `Greeter.sol` contract. 
+The `deploy-greeter.ts` script is in the `deploy` folder. This script uses the `Deployer` class from the `hardhat-zksync-deploy` package to deploy the `Greeter.sol` contract. 
 
 
 ```typescript

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -122,7 +122,6 @@ Successfully compiled 1 Solidity file
 The `artifacts-zk` and `cache-zk` folders appear in the root directory (instead of the regular Hardhat's `artifacts` and `cache`). These folders contain the compilation artifacts (including contract's ABIs) and compiler cache files.
 
 ::: tip
-
 Note that the `artifacts-zk` and `cache-zk` folders  are already included in the `.gitignore` file of the project.
 
 :::

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -118,7 +118,8 @@ Compiling 1 Solidity file
 Successfully compiled 1 Solidity file
 ✨  Done in 1.09s.
 ```
-The `artifacts-zk` and `cache-zk` folders will be created in the root directory (instead of the regular Hardhat's `artifacts` and `cache`). These folders contain the compilation artifacts (including contract's ABIs) and compiler cache files.
+
+The `artifacts-zk` and `cache-zk` folders appear in the root directory (instead of the regular Hardhat's `artifacts` and `cache`). These folders contain the compilation artifacts (including contract's ABIs) and compiler cache files.
 
 ::: tip
 

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -108,7 +108,7 @@ WALLET_PRIVATE_KEY=abcdef12345....
 
 Smart contracts belong in the `contracts` folder. The template project contains a simple `Greeter.sol` contract and a script to deploy it.
 
-To compile the contract, run:
+1. To compile the contract, run:
 
 ```sh
 yarn hardhat compile
@@ -188,7 +188,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 }
 ```
 
-To execute the deployment script run:
+2. To execute the deployment script run:
 
 ```sh
 yarn hardhat deploy-zksync --script deploy-greeter.ts
@@ -216,7 +216,9 @@ Greeter was deployed to 0x46f1d2d8A16DBD8b47e9D61175a826ac667288Be4D1293a22E8
 
 ## Interact with the contract
 
-The template project contains another script to interact with the contract, `use-greeter.ts`. To execute it, enter the address of the deployed Greeter contract in the `CONTRACT_ADDRESS` variable:
+The template project contains another script to interact with the contract. 
+
+1. Enter the address of the deployed Greeter contract in the `CONTRACT_ADDRESS` variable of the `use-greeter.ts` script:
 
 ```typescript
 import { Provider } from "zksync-web3";
@@ -270,7 +272,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
   console.log(`The message now is ${await contract.greet()}`);
 }
 ```
-To execute this script run:
+2. To execute the script, run:
 
 ```sh
 yarn hardhat deploy-zksync --script use-greeter.ts

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -106,12 +106,12 @@ WALLET_PRIVATE_KEY=abcdef12345....
 
 ## Compile and deploy a contract
 
-Smart contracts are placed in the `contracts` folder. The template project contains a simple `Greeter.sol` contract and a script to deploy it.
+Smart contracts belong in the `contracts` folder. The template project contains a simple `Greeter.sol` contract and a script to deploy it.
 
 To compile the contract, run:
+
 ```sh
 yarn hardhat compile
-``` 
 You'll see the following output:
 ```text
 Compiling 1 Solidity file

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -36,7 +36,7 @@ If you are using Vyper, check out the [Vyper plugin documentation](./hardhat-zks
 
 ## Project setup
 
-To create a new project run the `create` task of the CLI passing a project name:
+To create a new project run the CLI's `create` command, passing a project name:
 
 ```sh
 zksync-cli create demo 

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -58,7 +58,7 @@ import "@matterlabs/hardhat-zksync-deploy";
 import "@matterlabs/hardhat-zksync-solc";
 ```
 
-Dinamically change the network endpoints of the `zkSyncTestnet` network for local tests. This template project includes a basic unit test in the `/test` folder that runs with the local-setup and can be executed with `yarn test`. 
+Dinamically change the network endpoints of the `zkSyncTestnet` network for local tests. 
 
 ```typescript
 // dynamically changes endpoints for local tests
@@ -76,7 +76,7 @@ const zkSyncTestnet =
       };
 ```
 ::: tip Unit tests
-Learn more about how to [start the local setup and write unit tests here](./testing.md).
+This template project includes a basic unit test in the `/test` folder that runs with the local-setup and can be executed with `yarn test`. Learn more about how to [start the local setup and write unit tests here](./testing.md).
 :::
 
 The `zksolc` block contains the minimal configuration required for the compiler:

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -216,7 +216,7 @@ Greeter was deployed to 0x46f1d2d8A16DBD8b47e9D61175a826ac667288Be4D1293a22E8
 
 ## Interact with the contract
 
-The template project contains another script to interact with the contract, `use-greeter.ts`. To execute it, enter the address of the contract in the `CONTRACT_ADDRESS` variable:
+The template project contains another script to interact with the contract, `use-greeter.ts`. To execute it, enter the address of the deployed Greeter contract in the `CONTRACT_ADDRESS` variable:
 
 ```typescript
 import { Provider } from "zksync-web3";

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -52,13 +52,13 @@ If you want to migrate an existing project, please check the [project migration 
 
 The `hardhat.config.ts` file contains some zkSync-Era-specific configurations:
 
-Imports the zkSync deployment and compiler plugins.
+The zkSync Era deployment and compiler plugin imports.
 ```typescript
 import "@matterlabs/hardhat-zksync-deploy";
 import "@matterlabs/hardhat-zksync-solc";
 ```
 
-Dinamically change the network endpoints of the `zkSyncTestnet` network for local tests. 
+The network endpoints of the `zkSyncTestnet` network change dynamically for local tests.
 
 ```typescript
 // dynamically changes endpoints for local tests
@@ -79,7 +79,7 @@ const zkSyncTestnet =
 This template project includes a basic unit test in the `/test` folder that runs with the local-setup and can be executed with `yarn test`. Learn more about how to [start the local setup and write unit tests here](./testing.md).
 :::
 
-The `zksolc` block contains the minimal configuration required for the compiler:
+The `zksolc` block contains the minimal configuration required for the compiler.
 
 ```typescript
 zksolc: {
@@ -112,6 +112,8 @@ Smart contracts belong in the `contracts` folder. The template project contains 
 
 ```sh
 yarn hardhat compile
+```
+
 You'll see the following output:
 
 ```text

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -193,7 +193,7 @@ To execute the deployment script run
 ```sh
 yarn hardhat deploy-zksync --script deploy-greeter.ts
 ```
-This script will deploy the `Greeting` contract with the message "Hi there!" to zkSync Era Testnet.
+This script deploys the `Greeting` contract with the message "Hi there!" to zkSync Era Testnet.
 
 You should see something like this:
 

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -29,7 +29,7 @@ If you are using Vyper, check out the [Vyper plugin documentation](./hardhat-zks
 - You have a wallet with sufficient Göerli `ETH` on L1 to pay for bridging funds to zkSync as well as deploying smart contracts. We recommend using [our faucet from the zkSync portal](https://goerli.portal.zksync.io/faucet).
 - You know how to get your [private key from your MetaMask wallet](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
 
-::: warning Important notes
+::: warning Important
 - Contracts must be compiled using the [official zkSync Era compilers](../compiler-toolchain/README.md), with their respective Hardhat plugins.
 - Contracts compiled with other compilers will fail to deploy to zkSync Era.
 :::

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -50,7 +50,7 @@ If you want to migrate an existing project, please check the [project migration 
 
 ## Hardhat configuration
 
-The `hardhat.config.ts` file contains a few lines specific to zkSync Era. The most important are:
+The `hardhat.config.ts` file contains some zkSync-Era-specific configurations:
 
 Imports the zkSync deployment and compiler plugins.
 ```typescript

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -98,7 +98,7 @@ To learn more about each specific property in the `hardhat.config.ts` file, chec
 
 The project uses the `dotenv` package to load your private key which is required to deploy and interact with smart contracts.
 
-To configure it, duplicate the `.env.example` file, rename it to `.env`, and enter your wallet private key in it. The `.env` is included in the `.gitignore` file so it won't be uploaded to a repository.
+To configure it, copy the `.env.example` file, rename the copy to `.env`, and add your wallet private key. The `.env` file is included in `.gitignore` so it won't upload to a repository.
 
 ```text
 WALLET_PRIVATE_KEY=abcdef12345....

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -18,7 +18,7 @@ Learn more about [other plugins from the community](./other-plugins.md) that you
 
 To learn more about Hardhat itself, check out [its official documentation](https://hardhat.org/getting-started/).
 
-This tutorial shows how to set up a zkSync Era Solidity project with Hardhat using the [zkSync CLI](../tools/zksync-cli/README.md).
+This tutorial shows you how to set up a zkSync Era Solidity project with Hardhat using the [zkSync CLI](../tools/zksync-cli/README.md).
 
 If you are using Vyper, check out the [Vyper plugin documentation](./hardhat-zksync-vyper.md) or [this example](https://github.com/matter-labs/hardhat-zksync/tree/main/examples/vyper-example) in GitHub!
 

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -11,7 +11,6 @@ zkSync Era has the following official plugins for Hardhat:
 - [@matterlabs/hardhat-zksync-verify](./hardhat-zksync-verify.md) - used to verify smart contracts.
 
 ::: tip Additional plugins
-
 Learn more about [other plugins from the community](./other-plugins.md) that you can use with zkSync Era.
 
 :::

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -113,6 +113,7 @@ To compile the contract, run:
 ```sh
 yarn hardhat compile
 You'll see the following output:
+
 ```text
 Compiling 1 Solidity file
 Successfully compiled 1 Solidity file
@@ -122,7 +123,7 @@ Successfully compiled 1 Solidity file
 The `artifacts-zk` and `cache-zk` folders appear in the root directory (instead of the regular Hardhat's `artifacts` and `cache`). These folders contain the compilation artifacts (including contract's ABIs) and compiler cache files.
 
 ::: tip
-Note that the `artifacts-zk` and `cache-zk` folders  are already included in the `.gitignore` file of the project.
+The `artifacts-zk` and `cache-zk` folders  are included in the `.gitignore` file.
 
 :::
 
@@ -187,7 +188,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 }
 ```
 
-To execute the deployment script run
+To execute the deployment script run:
 
 ```sh
 yarn hardhat deploy-zksync --script deploy-greeter.ts

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -31,23 +31,22 @@ If you are using Vyper, check out the [Vyper plugin documentation](./hardhat-zks
 - You have a wallet with sufficient Göerli `ETH` on L1 to pay for bridging funds to zkSync as well as deploying smart contracts. We recommend using [our faucet from the zkSync portal](https://goerli.portal.zksync.io/faucet).
 - You know how to get your [private key from your MetaMask wallet](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
 
-::: warning
-- Contracts must be compiled using the official zkSync Era plugins. 
-- Contracts compiled with other compilers will fail to deploy to zkSync Era using this plugin.
+::: warning Important notes
+- Contracts must be compiled using the [official zkSync Era compilers](../compiler-toolchain/README.md), with their respective Hardhat plugins.
+- Contracts compiled with other compilers will fail to deploy to zkSync Era.
 :::
 
-## Setup
+## Project setup
 
-To create a new project run:
+To create a new project run the `create` task of the CLI passing a project name:
 
 ```sh
-zksync-cli create demo // or any other project name
+zksync-cli create demo 
 ```
-This command will clone a Hardhat template project already configured and with all the required plugins.
-
+This command will create a `demo` folder and clone a Hardhat template project inside it. The downloaded project is already configured and contains all the required plugins.
 
 ::: tip Migrating a project
-If you want to migrate an existing project, please check the [Hardhat project migration guide](./migrating-to-zksync.md).
+If you want to migrate an existing project, please check the [project migration guide](./migrating-to-zksync.md).
 :::
 
 
@@ -62,10 +61,6 @@ import "@matterlabs/hardhat-zksync-solc";
 ```
 
 Dinamically change the network endpoints of the `zkSyncTestnet` network for local tests. This template project includes a basic unit test in the `/test` folder that runs with the local-setup and can be executed with `yarn test`. 
-
-::: tip Unit tests
-Learn more about how to [start the local setup and write unit tests here](./testing.md).
-:::
 
 ```typescript
 // dynamically changes endpoints for local tests
@@ -82,6 +77,9 @@ const zkSyncTestnet =
         zksync: true
       };
 ```
+::: tip Unit tests
+Learn more about how to [start the local setup and write unit tests here](./testing.md).
+:::
 
 The `zksolc` block contains the minimal configuration required for the compiler:
 
@@ -103,6 +101,10 @@ To learn more about each specific property in the `hardhat.config.ts` file, chec
 This project uses the `dotenv` package to load your private key, which is required to deploy and interact with smart contracts.
 
 To configure it, duplicate the `.env.example` file, rename it to `.env`, and enter your wallet private key in it. The `.env` is included in the `.gitignore` file so it won't be uploaded to a repository.
+
+```text
+WALLET_PRIVATE_KEY=abcdef12345....
+```
 
 ## Compile and deploy a contract
 

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -96,7 +96,7 @@ To learn more about each specific property in the `hardhat.config.ts` file, chec
 
 ## Environment variables
 
-This project uses the `dotenv` package to load your private key, which is required to deploy and interact with smart contracts.
+The project uses the `dotenv` package to load your private key which is required to deploy and interact with smart contracts.
 
 To configure it, duplicate the `.env.example` file, rename it to `.env`, and enter your wallet private key in it. The `.env` is included in the `.gitignore` file so it won't be uploaded to a repository.
 

--- a/docs/api/hardhat/migrating-to-zksync.md
+++ b/docs/api/hardhat/migrating-to-zksync.md
@@ -74,6 +74,30 @@ zksolc: {
 ```
 For more advanced settings, check out the [Solidity](./hardhat-zksync-solc.md) or [Vyper](./hardhat-zksync-vyper.md) plugins.
 
+
+### How to configure multiple compilation targets
+
+To configure the `hardhat.config.ts` file to target both zkSync Era and other networks, do the following:
+
+1. In your `hardhat.config.ts`, configure the zkSync Era network with `zksync: true`.
+2. Configure all other networks with `zksync: false`.
+3. Run the compilation or deployment scripts with the network flag: `yarn hardhat compile --network zkSyncTestnet` for zkSync Era network or `yarn hardhat compile --network goerli` for other networks, e.g goerli.
+
+```typescript
+networks: {
+    goerli: {
+      url: "https://goerli.infura.io/v3/<API_KEY>", // The Ethereum Web3 RPC URL.
+      zksync: false, // Set to false to target other networks.
+    },
+    zkSyncTestnet: {
+      url: "https://testnet.era.zksync.dev", // The testnet RPC URL of zkSync Era network.
+      ethNetwork: "goerli", // The identifier of the network (e.g. `mainnet` or `goerli`)
+    zksync: true, // Set to true to target zkSync Era.
+    }
+},
+
+```
+
 ### Full configuration
 
 Here is an example config file:
@@ -144,10 +168,8 @@ If your contracts import any non-inlineable libraries, you need to configure the
 
 ## Deploy contracts
 
-::: tip Test ETH
-
-Obtain [test ETH from our faucet](https://goerli.portal.zksync.io/faucet) or just bridge GöerliETH using [the zkSync Portal](https://goerli.portal.zksync.io/bridge).
-
+::: tip hardhat-deploy support
+hardhat-deploy version `^0.11.26` supports deployments on zkSync Era.
 :::
 
 To deploy your contracts you need to use the `Deployer` class from the `hardhat-zksync-deploy`  plugin. This class takes care of all the specifics of [deploying contracts on zkSync](../../dev/building-on-zksync/contracts/contract-deployment.md). 
@@ -183,6 +205,12 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 }
 
 ```
+::: tip Test ETH
+
+Obtain [test ETH from our faucet](https://goerli.portal.zksync.io/faucet) or just bridge GöerliETH using [the zkSync Portal](https://goerli.portal.zksync.io/bridge).
+
+:::
+
 Include your deployment script in the `deploy` folder and execute it running:
 
 ::: code-tabs

--- a/docs/api/hardhat/migrating-to-zksync.md
+++ b/docs/api/hardhat/migrating-to-zksync.md
@@ -207,7 +207,6 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 ```
 ::: tip Test ETH
 Obtain [test ETH from our faucet](https://goerli.portal.zksync.io/faucet) or just bridge GöerliETH using [the zkSync Portal](https://goerli.portal.zksync.io/bridge).
-
 :::
 
 Include your deployment script in the `deploy` folder and execute it running:

--- a/docs/api/hardhat/migrating-to-zksync.md
+++ b/docs/api/hardhat/migrating-to-zksync.md
@@ -206,7 +206,6 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 
 ```
 ::: tip Test ETH
-
 Obtain [test ETH from our faucet](https://goerli.portal.zksync.io/faucet) or just bridge GöerliETH using [the zkSync Portal](https://goerli.portal.zksync.io/bridge).
 
 :::

--- a/docs/api/hardhat/migrating-to-zksync.md
+++ b/docs/api/hardhat/migrating-to-zksync.md
@@ -168,7 +168,7 @@ If your contracts import any non-inlineable libraries, you need to configure the
 
 ## Deploy contracts
 
-::: tip hardhat-deploy support
+::: tip `hardhat-deploy` support
 `hardhat-deploy` version `^0.11.26` supports deployments on zkSync Era.
 :::
 

--- a/docs/api/hardhat/migrating-to-zksync.md
+++ b/docs/api/hardhat/migrating-to-zksync.md
@@ -169,7 +169,7 @@ If your contracts import any non-inlineable libraries, you need to configure the
 ## Deploy contracts
 
 ::: tip hardhat-deploy support
-hardhat-deploy version `^0.11.26` supports deployments on zkSync Era.
+`hardhat-deploy` version `^0.11.26` supports deployments on zkSync Era.
 :::
 
 To deploy your contracts you need to use the `Deployer` class from the `hardhat-zksync-deploy`  plugin. This class takes care of all the specifics of [deploying contracts on zkSync](../../dev/building-on-zksync/contracts/contract-deployment.md). 


### PR DESCRIPTION
Changes HH quickstart to use CLI
Moves "Multiple targets" section to migration guide.
Adds info for hardhat-deploy in migration guide.