### PR TITLE
Add unsupported Solidity functions

### DIFF
--- a/docs/dev/building-on-zksync/contracts/contract-development.md
+++ b/docs/dev/building-on-zksync/contracts/contract-development.md
@@ -16,7 +16,7 @@ Please read [this section of the docs](../../../api/compiler-toolchain/solidity.
 
 ### Unsupported functions
 
-We current do not support the following Solidity functions:
+We currently do not support the following Solidity functions:
 
 - `runtimeCode`
 - `creationCode`

--- a/docs/dev/building-on-zksync/contracts/contract-development.md
+++ b/docs/dev/building-on-zksync/contracts/contract-development.md
@@ -14,6 +14,13 @@ Currently, Solidity versions as old as `0.4.12` are supported, although **we str
 
 Please read [this section of the docs](../../../api/compiler-toolchain/solidity.md#using-libraries) if your project uses libraries.
 
+### Unsupported functions
+
+We current do not support the following Solidity functions:
+
+- `runtimeCode`
+- `creationCode`
+
 ## Vyper support
 
 Currently only Vyper `^0.3.3` is supported.


### PR DESCRIPTION
Minor addition to docs with regards to unsupported Solidity functions.

From ticket here: https://linear.app/matterlabs/issue/DOC-261/document-we-do-not-support-the-following-solidity-methods