### PR TITLE
vyper support

### DIFF
--- a/docs/dev/building-on-zksync/contracts/contract-development.md
+++ b/docs/dev/building-on-zksync/contracts/contract-development.md
@@ -23,7 +23,7 @@ We currently do not support the following Solidity functions:
 
 ## Vyper support
 
-Currently only Vyper `^0.3.3` is supported.
+Currently only Vyper `0.3.3` is supported.
 
 ## Compilers
 


### PR DESCRIPTION
Stated clearly that we support only Vyper `0.3.3`.