### PR TITLE
Added redirect to broken link on website

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -100,7 +100,7 @@
         },
         {
           "source": "/docs/dev/fundamentals/faq.html",
-          "destination": "/docsapi/compiler-toolchain/overview.html",
+          "destination": "/docs/api/compiler-toolchain/overview.html",
           "type": "302"
         }
       ]
@@ -205,7 +205,7 @@
         },
         {
           "source": "/docs/dev/fundamentals/faq.html",
-          "destination": "/docsapi/compiler-toolchain/overview.html",
+          "destination": "/docs/api/compiler-toolchain/overview.html",
           "type": "302"
         }
       ]

--- a/firebase.json
+++ b/firebase.json
@@ -97,6 +97,11 @@
           "source": "/docs/dev/fundamentals/testnet.html",
           "destination": "/docs/dev/fundamentals/interacting.html",
           "type": "302"
+        },
+        {
+          "source": "/docs/dev/fundamentals/faq.html",
+          "destination": "/docsapi/compiler-toolchain/overview.html",
+          "type": "302"
         }
       ]
     },
@@ -196,6 +201,11 @@
         {
           "source": "/docs/dev/fundamentals/testnet.html",
           "destination": "/docs/dev/fundamentals/interacting.html",
+          "type": "302"
+        },
+        {
+          "source": "/docs/dev/fundamentals/faq.html",
+          "destination": "/docsapi/compiler-toolchain/overview.html",
           "type": "302"
         }
       ]

--- a/firebase.json
+++ b/firebase.json
@@ -99,8 +99,8 @@
           "type": "302"
         },
         {
-          "source": "/docs/dev/fundamentals/faq.html#what-is-the-zkevm",
-          "destination": "/docs/dev/troubleshooting/faq.html#what-is-the-zkevm",
+          "source": "/docs/dev/fundamentals/faq.html",
+          "destination": "/docs/dev/troubleshooting/faq.html",
           "type": "302"
         }
       ]
@@ -204,8 +204,8 @@
           "type": "302"
         },
         {
-          "source": "/docs/dev/fundamentals/faq.html#what-is-the-zkevm",
-          "destination": "/docs/dev/troubleshooting/faq.html#what-is-the-zkevm",
+          "source": "/docs/dev/fundamentals/faq.html",
+          "destination": "/docs/dev/troubleshooting/faq.html",
           "type": "302"
         }
       ]

--- a/firebase.json
+++ b/firebase.json
@@ -99,8 +99,8 @@
           "type": "302"
         },
         {
-          "source": "/docs/dev/fundamentals/faq.html/#what-is-the-zkevm",
-          "destination": "/docs/dev/troubleshooting/faq.html/#what-is-the-zkevm",
+          "source": "/docs/dev/fundamentals/faq.html#what-is-the-zkevm",
+          "destination": "/docs/dev/troubleshooting/faq.html#what-is-the-zkevm",
           "type": "302"
         }
       ]
@@ -204,8 +204,8 @@
           "type": "302"
         },
         {
-          "source": "/docs/dev/fundamentals/faq.html/#what-is-the-zkevm",
-          "destination": "/docs/dev/troubleshooting/faq.html/#what-is-the-zkevm",
+          "source": "/docs/dev/fundamentals/faq.html#what-is-the-zkevm",
+          "destination": "/docs/dev/troubleshooting/faq.html#what-is-the-zkevm",
           "type": "302"
         }
       ]

--- a/firebase.json
+++ b/firebase.json
@@ -99,8 +99,8 @@
           "type": "302"
         },
         {
-          "source": "/docs/dev/fundamentals/faq.html",
-          "destination": "/docs/api/compiler-toolchain/overview.html",
+          "source": "/docs/dev/fundamentals/faq.html/#what-is-the-zkevm",
+          "destination": "/docs/dev/troubleshooting/faq.html/#what-is-the-zkevm",
           "type": "302"
         }
       ]
@@ -204,8 +204,8 @@
           "type": "302"
         },
         {
-          "source": "/docs/dev/fundamentals/faq.html",
-          "destination": "/docs/api/compiler-toolchain/overview.html",
+          "source": "/docs/dev/fundamentals/faq.html/#what-is-the-zkevm",
+          "destination": "/docs/dev/troubleshooting/faq.html/#what-is-the-zkevm",
           "type": "302"
         }
       ]


### PR DESCRIPTION
Redirected the broken link on Matterlabs website homepage from `/dev/fundamentals/faq.html` to `/dev/troubleshooting/faq.html`.

To test, go to the faq [page](https://aqwzx-zksync-v2-docs--pr457-redirect-link-doc-29-x2nhqtu4.web.app/docs/dev/fundamentals/faq.html), it should redirect you to the [right](https://aqwzx-zksync-v2-docs--pr457-redirect-link-doc-29-x2nhqtu4.web.app/docs/dev/troubleshooting/faq.html) page.