### PR TITLE
Add getL1BatchDetails, tidy docs a wee bit, update Types, include Custom Bridge updates DOC-288

### DIFF
--- a/docs/.vuepress/sidebar/en.ts
+++ b/docs/.vuepress/sidebar/en.ts
@@ -79,7 +79,7 @@ export const enSidebar = sidebar({
       link: "/api/api.md", // optional, which should be a absolute path.
     },
     {
-      text: "TypeScript SDK", // required
+      text: "JavaScript SDK", // required
       link: "/api/js", // optional, which should be a absolute path.
       children: [
         "/api/js/getting-started",

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,7 +12,7 @@ Our SDKs enable you to build web3 applications, with capabilities such as:
 
 ## SDKs
 
-- [JavaScript SDK](./js)
+- [TypeScript SDK](./js)
 - [Python SDK](./python/getting-started.md)
 - [GO SDK](./go/getting-started.md)
 - [Java SDK](./java/getting-started.md)

--- a/docs/api/js/README.md
+++ b/docs/api/js/README.md
@@ -1,8 +1,8 @@
-# JS Web3 SDK
+# TypeScript Web3 SDK
 
 While most of the existing SDKs should work out of the box, deploying smart contracts or using unique zkSync features, like paying fees in other tokens, requires providing additional fields to those that Ethereum transactions have by default.
 
-To provide easy access to all of the features of zkSync Era, the `zksync-web3` JavaScript SDK was created, which is based on the `ethers.js` library. This section serves as its reference.
+To provide easy access to all of the features of zkSync Era, the `zksync-web3` TypeScript SDK was created, which is based on the `ethers.js` library. This section serves as its reference.
 
 ## Table of contents
 
@@ -13,5 +13,6 @@ To provide easy access to all of the features of zkSync Era, the `zksync-web3` J
 - [Contracts](./contracts.md)
 - [zkSync Era features](./features.md)
 - [Utilities](./utils.md)
+- [Paymaster utilities](./paymaster-utils.md)
 - [Types](./types.md)
 - [Front-end integration](./front-end.md)

--- a/docs/api/js/README.md
+++ b/docs/api/js/README.md
@@ -1,8 +1,8 @@
-# TypeScript Web3 SDK
+# JavaScript Web3 SDK
 
 While most of the existing SDKs should work out of the box, deploying smart contracts or using unique zkSync features, like paying fees in other tokens, requires providing additional fields to those that Ethereum transactions have by default.
 
-To provide easy access to all of the features of zkSync Era, the `zksync-web3` TypeScript SDK was created, which is based on the `ethers.js` library. This section serves as its reference.
+To provide easy access to all of the features of zkSync Era, the `zksync-web3` JavaScript SDK was created, which is based on the `ethers.js` library. This section serves as its reference.
 
 ## Table of contents
 

--- a/docs/api/js/providers.md
+++ b/docs/api/js/providers.md
@@ -18,9 +18,9 @@ The `zksync-web3` library exports two types of providers:
 
 This is the most commonly used type of provider. It provides the same functionality as `ethers.providers.JsonRpcProvider`, but extends it with the zkSync-specific methods.
 
-### Creating provider
+### `constructor`
 
-The constructor accepts the `url` to the operator node and the `network` name (optional).
+The constructor accepts the `url` to the operator node and the `network` name (optional) and returns a `Provider` object.
 
 ```typescript
 constructor(url?: ConnectionInfo | string, network?: ethers.providers.Networkish)
@@ -77,67 +77,6 @@ console.log(await provider.getBalance("0x0614BB23D91625E60c24AAD6a2E6e2c03461ebC
 console.log(await provider.getBalance("0x0614BB23D91625E60c24AAD6a2E6e2c03461ebC5"));
 ```
 
-### Getting the zkSync smart contract address
-
-```typescript
-async getMainContractAddress(): Promise<string>
-```
-
-#### Inputs and outputs
-
-| Name    | Description                               |
-| ------- | ----------------------------------------- |
-| returns | The address of the zkSync smart contract. |
-
-> Example
-
-```typescript
-import { Provider } from "zksync-web3";
-
-const provider = new Provider("https://testnet.era.zksync.dev");
-
-console.log(await provider.getMainContractAddress());
-```
-
-### Getting testnet paymaster address
-
-On zkSync testnets, the [testnet paymaster](../../dev/developer-guides/aa.md#paymasters) is available.
-
-```typescript
-async getTestnetPaymasterAddress(): Promise<string|null>
-```
-
-#### Inputs and outputs
-
-| Name    | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
-| returns | The address of the testnet paymaster or `null` if there isn't any. |
-
-> Example
-
-```typescript
-import { Provider } from "zksync-web3";
-
-const provider = new Provider("https://testnet.era.zksync.dev");
-
-console.log(await provider.getTestnetPaymasterAddress());
-```
-
-### Getting zkSync default bridge contract addresses
-
-```typescript
-async getDefaultBridgeAddresses(): Promise<{
-    erc20L1: string;
-    erc20L2: string;
-}>
-```
-
-#### Inputs and outputs
-
-| Name    | Description                                                        |
-| ------- | ------------------------------------------------------------------ |
-| returns | The addresses of default zkSync bridge contracts on both L1 and L2 |
-
 ### `getConfirmedTokens`
 
 Returns [address, symbol, name, and decimal] information of all tokens within a range of ids given by parameters `start` and `limit`.
@@ -165,6 +104,86 @@ import { Provider } from "zksync-web3";
 const provider = new Provider("https://testnet.era.zksync.dev");
 
 console.log(await provider.getConfirmedTokens());
+```
+
+### `getDefaultBridgeAddresses`
+
+```typescript
+async getDefaultBridgeAddresses(): Promise<{
+    erc20L1: string;
+    erc20L2: string;
+}>
+```
+
+#### Inputs and outputs
+
+| Name    | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
+| returns | The addresses of default zkSync bridge contracts on both L1 and L2 |
+
+### `getL1BatchDetails`
+
+Calls `zks_getL1BatchDetails` which returns zkSync-specific information about the layer 2 block.
+
+```ts
+async getL1BatchDetails(number: number): Promise<BatchDetails> {
+        return await this.send('zks_getL1BatchDetails', [number]);
+}
+```
+
+#### Inputs and outputs
+
+| Name    | Description                               |
+| ------- | ----------------------------------------- |
+| `number` | The batch number on layer 2. |
+| returns | Information about the batch. |
+
+### `getMainContractAddress`
+
+Returns the main zkSync smart contract address.
+
+```typescript
+async getMainContractAddress(): Promise<string>
+```
+
+#### Inputs and outputs
+
+| Name    | Description                               |
+| ------- | ----------------------------------------- |
+| returns | The address of the zkSync smart contract. |
+
+> Example
+
+```typescript
+import { Provider } from "zksync-web3";
+
+const provider = new Provider("https://testnet.era.zksync.dev");
+
+console.log(await provider.getMainContractAddress());
+```
+
+### `getTestnetPaymasterAddress`
+
+On zkSync testnets, the [testnet paymaster](../../dev/developer-guides/aa.md#paymasters) is available.
+
+```typescript
+async getTestnetPaymasterAddress(): Promise<string|null>
+```
+
+#### Inputs and outputs
+
+| Name    | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
+| returns | The address of the testnet paymaster or `null` if there isn't any. |
+
+> Example
+
+```typescript
+import { Provider } from "zksync-web3";
+
+const provider = new Provider("https://testnet.era.zksync.dev");
+
+console.log(await provider.getTestnetPaymasterAddress());
 ```
 
 ### `getTokenPrice`
@@ -195,48 +214,6 @@ const provider = new Provider("https://testnet.era.zksync.dev");
 console.log(await provider.getTokenPrice(USDC_L2_ADDRESS));
 ```
 
-### Getting token's address on L2 from its L1 address and vice-versa
-
-Token's address on L2 will not be the same as on L1.
-ETH's address is set to zero address on both networks.
-
-Provided methods work only for tokens bridged using default zkSync bridges.
-
-```typescript
-// takes L1 address, returns L2 address
-async l2TokenAddress(l1Token: Address): Promise<string>
-// takes L2 address, returns L1 address
-async l1TokenAddress(l2Token: Address): Promise<string>
-```
-
-| Name    | Description                                      |
-| ------- | ------------------------------------------------ |
-| token   | The address of the token on the one layer.       |
-| returns | The address of that token on the opposite layer. |
-
-### `getTransactionStatus`
-
-Given a transaction hash, returns the status of the transaction.
-
-```typescript
-async getTransactionStatus(txHash: string): Promise<TransactionStatus>
-```
-
-| Name    | Description                                                                                                                |
-| ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| txHash   | zkSync transaction hash.                                                                                                  |
-| returns | The status of the transaction. You can find the description for `TransactionStatus` enum variants in the [types](./types). |
-
-> Example
-
-```typescript
-import { Provider } from "zksync-web3";
-const provider = new Provider("https://testnet.era.zksync.dev");
-
-const TX_HASH = "0x95395d90a288b29801c77afbe359774d4fc76c08879b64708c239da8a65dbcf3";
-console.log(await provider.getTransactionStatus(TX_HASH));
-```
-
 ### `getTransaction`
 
 Given a transaction hash, returns the L2 transaction response object.
@@ -265,11 +242,53 @@ await txHandle.wait();
 await txHandle.waitFinalize();
 ```
 
+### `getTransactionStatus`
+
+Given a transaction hash, returns the status of the transaction.
+
+```typescript
+async getTransactionStatus(txHash: string): Promise<TransactionStatus>
+```
+
+| Name    | Description                                                                                                                |
+| ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| txHash   | zkSync transaction hash.                                                                                                  |
+| returns | The status of the transaction. You can find the description for `TransactionStatus` enum variants in the [types](./types). |
+
+> Example
+
+```typescript
+import { Provider } from "zksync-web3";
+const provider = new Provider("https://testnet.era.zksync.dev");
+
+const TX_HASH = "0x95395d90a288b29801c77afbe359774d4fc76c08879b64708c239da8a65dbcf3";
+console.log(await provider.getTransactionStatus(TX_HASH));
+```
+
+### `l1TokenAddress` and `l2TokenAddress`
+
+Returns the equivalent token address on the respective layer as token addresses on L2 are not equal to those on L1.
+ETH's address is set to zero address on both networks.
+
+Provided methods work only for tokens bridged using default zkSync bridges.
+
+```typescript
+// takes L1 address, returns L2 address
+async l2TokenAddress(l1Token: Address): Promise<string>
+// takes L2 address, returns L1 address
+async l1TokenAddress(l2Token: Address): Promise<string>
+```
+
+| Name    | Description                                      |
+| ------- | ------------------------------------------------ |
+| token   | The address of the token on the one layer.       |
+| returns | The address of that token on the opposite layer. |
+
 ## `Web3Provider`
 
 A class that should be used for web3 browser wallet integrations, adapted for easy compatibility with Metamask, WalletConnect, and other popular browser wallets.
 
-### Creating `Web3Provider`
+### `constructor`
 
 The main difference from the constructor of `Provider` class is that it accepts `ExternalProvider` instead of the node URL.
 
@@ -293,9 +312,9 @@ import { Web3Provider } from "zksync-web3";
 const provider = new Web3Provider(window.ethereum);
 ```
 
-### Getting zkSync signer
+### `getSigner`
 
-Returns a `Signer` object that can be used to sign zkSync transactions. More details on the `Signer` class can be found in the next [section](./accounts.md#signer).
+Returns a `Signer` object for signing zkSync transactions. More details on the `Signer` class can be found in the next [section](./accounts.md#signer).
 
 #### Inputs and outputs
 

--- a/docs/api/js/types.md
+++ b/docs/api/js/types.md
@@ -2,7 +2,7 @@
 
 All the types which are used in the SDK are referenced here:
 <!-- TODO SMA-1725: prepare quality documentation for SDK types with proper description and explanation -->
-```typescript
+```ts
 import { BytesLike, BigNumberish, providers, BigNumber } from 'ethers';
 import { BlockWithTransactions as EthersBlockWithTransactions } from '@ethersproject/abstract-provider';
 
@@ -18,6 +18,17 @@ export enum Network {
     Rinkeby = 4,
     Goerli = 5,
     Localhost = 9
+}
+
+export enum PriorityQueueType {
+    Deque = 0,
+    HeapBuffer = 1,
+    Heap = 2
+}
+
+export enum PriorityOpTree {
+    Full = 0,
+    Rollup = 1
 }
 
 export enum TransactionStatus {
@@ -39,6 +50,7 @@ export type Eip712Meta = {
     paymasterParams?: PaymasterParams;
 };
 
+// prettier-ignore
 export type BlockTag =
     | number
     | string // hex number
@@ -48,6 +60,7 @@ export type BlockTag =
     | 'earliest'
     | 'pending';
 
+// TODO (SMA-1585): Support create2 variants.
 export type DeploymentType = 'create' | 'createAccount';
 
 export interface Token {
@@ -167,9 +180,27 @@ export interface ContractAccountInfo {
     nonceOrdering: AccountNonceOrdering;
 }
 
+export interface BatchDetails {
+    number: number;
+    timestamp: number;
+    l1TxCount: number;
+    l2TxCount: number;
+    rootHash?: string;
+    status: string;
+    commitTxHash?: string;
+    committedAt?: Date;
+    proveTxHash?: string;
+    provenAt?: Date;
+    executeTxHash?: string;
+    executedAt?: Date;
+    l1GasPrice: number;
+    l2FairGasPrice: number;
+}
+
 export interface BlockDetails {
     number: number;
     timestamp: number;
+    l1BatchNumber: number;
     l1TxCount: number;
     l2TxCount: number;
     rootHash?: string;

--- a/docs/dev/developer-guides/bridging/bridging-asset.md
+++ b/docs/dev/developer-guides/bridging/bridging-asset.md
@@ -174,32 +174,13 @@ Users must call the `withdraw` method on the L2 bridge contract, which will trig
 On the testnet environment, we automatically finalize all withdrawals, i.e., for every withdrawal, we will take care of it by making an L1 transaction that proves the inclusion for each message.
 :::
 
-## Custom bridges
+## Custom bridges on L1 and L2
 
-Implement your own custom bridge by creating a new `L1ERC20BridgeFactory` and using it to deploy a custom bridge by passing the `CONTRACTS_DIAMOND_PROXY_ADDR` and an `allowlist` for the contract signer to the `deploy` function. 
+To build a custom bridge, create a regular Solidity contract which extends the correct interface for the layer.
 
-After the initial custom bridge set up, create a `TransparentUpgradeableProxyFactory` and use it to deploy the bridge address you just created.
+- L1: [IL1Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/ethereum/contracts/bridge/interfaces/IL1Bridge.sol)
+- L2: [L2ERC20Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/zksync/contracts/bridge/L2ERC20Bridge.sol)
 
-For example:
+The interfaces provide access to the zkSync Era SDK deposit and withdraw implementations.
 
-```ts
-let l1bridgeFactory = new L1ERC20BridgeFactory(alice._signerL1());
-const gasPrice = await scaledGasPrice(alice);
-
-let l1Bridge = await l1bridgeFactory.deploy(
-
-  process.env.CONTRACTS_DIAMOND_PROXY_ADDR!,
-  allowListContract.address
-        
-);
-
-await l1Bridge.deployTransaction.wait(2);
-    
-    let l1BridgeProxyFactory = new TransparentUpgradeableProxyFactory(alice._signerL1());
-    let l1BridgeProxy = await l1BridgeProxyFactory.deploy(l1Bridge.address, bob.address, '0x');
-    const amount = 1000; // 1 wei is enough.
-    await l1BridgeProxy.deployTransaction.wait(2);
-    ...
-```
-
-Check the docs for the [full code of the snippet above](https://github.com/matter-labs/zksync-2-dev/blob/main/core/tests/ts-integration/tests/custom-erc20-bridge.test.ts).
+For more info, check out an example [custom bridge implementation](https://github.com/matter-labs/zksync-2-dev/blob/main/core/tests/ts-integration/tests/custom-erc20-bridge.test.ts).

--- a/docs/dev/developer-guides/bridging/bridging-asset.md
+++ b/docs/dev/developer-guides/bridging/bridging-asset.md
@@ -176,11 +176,13 @@ On the testnet environment, we automatically finalize all withdrawals, i.e., for
 
 ## Custom bridges on L1 and L2
 
-To build a custom bridge, create a regular Solidity contract which extends the correct interface for the layer.
+To build a custom bridge, create a regular Solidity contract which extends the correct interface for the layer. The interfaces provide access to the zkSync Era SDK deposit and withdraw implementations.
 
 - L1: [IL1Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/ethereum/contracts/bridge/interfaces/IL1Bridge.sol)
+
+  For more information, check out our example [L1 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/ethereum/contracts/bridge/L1ERC20Bridge.sol).
+
+
 - L2: [L2ERC20Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/zksync/contracts/bridge/L2ERC20Bridge.sol)
 
-The interfaces provide access to the zkSync Era SDK deposit and withdraw implementations.
-
-For more info, check out an example [custom bridge implementation](https://github.com/matter-labs/zksync-2-dev/blob/main/core/tests/ts-integration/tests/custom-erc20-bridge.test.ts).
+  For more information, check out our example [L2 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/zksync/contracts/bridge/L2ERC20Bridge.sol).


### PR DESCRIPTION
- Added `getL1BatchDetails`
- Some wordage fixes: TS vs JS, function name vs explanation, alpha list
- Copy/paste `Types` code from source ... to be documented properly shortly in DOC-276
- Added Custom Bridge updates from DOC-288 also
