### PR TITLE
Redirect block section 

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -44,6 +44,11 @@
           "type": "302"
         },
         {
+          "source": "/docs/dev/developer-guides/transactions/blocks.html#blocks-in-zksync-2-0",
+          "destination": "/docs/dev/developer-guides/transactions/blocks.html#blocks-in-zksync-era",
+          "type": "302"
+        },
+        {
           "source": "/docs/contact.html",
           "destination": "/docs/#footer",
           "type": "302"


### PR DESCRIPTION
Redirected the block section from the [old docs](https://docs-v2-zksync.web.app/dev/developer-guides/transactions/blocks.html#blocks-in-zksync-2-0) to the [new docs](https://era.zksync.io/docs/dev/developer-guides/transactions/blocks.html#blocks-in-zksync-era)