### PR TITLE
Updated contract-deployment.md for clarity

### DIFF
--- a/docs/dev/building-on-zksync/contracts/contract-deployment.md
+++ b/docs/dev/building-on-zksync/contracts/contract-deployment.md
@@ -63,9 +63,9 @@ The process of auditing a smart contract should be carried out by experts who ha
 
 For detailed information on smart contract vulnerabilities and security best practices, refer to the following resources:
 
-- (Consensys smart contract best practices)[https://consensys.github.io/smart-contract-best-practices/].
+- [Consensys smart contract best practices](https://consensys.github.io/smart-contract-best-practices/).
 
-- (Solidity docs security considerations)[https://docs.soliditylang.org/en/latest/security-considerations.html].
+- [Solidity docs security considerations](https://docs.soliditylang.org/en/latest/security-considerations.html).
 
 ### Differences in `create()` behaviour
 


### PR DESCRIPTION
- The grammar was off where punctuation matters.
- Programming languages differentiate between cases in naming conventions. `CREATE` was changed to `create()`.
- Extended a subheading for clarity; etc.