### PR TITLE
chore: Update references from `incrementNonceIfEquals` to `incrementMinNonceIfEquals`

### DIFF
--- a/docs/dev/developer-guides/aa.md
+++ b/docs/dev/developer-guides/aa.md
@@ -51,7 +51,7 @@ Users will be allowed to use any 256-bit number as nonce and they can put any no
 the protocol, but not on the server side.
 
 More documentation on various interactions with the `NonceHolder` system contract as well as tutorials will be available once support on the server side is released. For now,
-it is recommended to only use the `incrementNonceIfEquals` method, which practically enforces the sequential ordering of nonces.
+it is recommended to only use the `incrementMinNonceIfEquals` method, which practically enforces the sequential ordering of nonces.
 
 ### Standardizing transaction hashes
 
@@ -204,7 +204,7 @@ Currently, your transactions may pass through the API despite violating the requ
 ### Nonce holder contract
 
 For optimization purposes, both [tx nonce and the deployment nonce](../building-on-zksync/contracts/contract-deployment.md#differences-in-create-behaviour) are put in one storage slot inside the [NonceHolder](./system-contracts.md#nonceholder) system contracts.
-In order to increment the nonce of your account, it is highly recommended to call the [incrementNonceIfEquals](https://github.com/matter-labs/v2-testnet-contracts/blob/main/l2/system-contracts/interfaces/INonceHolder.sol#L12) function and pass the value of the nonce provided in the transaction.
+In order to increment the nonce of your account, it is highly recommended to call the [incrementMinNonceIfEquals](https://github.com/matter-labs/v2-testnet-contracts/blob/b8449bf9c819098cc8bfee0549ff5094456be51d/l2/system-contracts/interfaces/INonceHolder.sol#L34) function and pass the value of the nonce provided in the transaction.
 
 This is one of the whitelisted calls, where the account logic is allowed to call outside smart contracts.
 

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -344,7 +344,7 @@ The transaction validation process is responsible for validating the signature o
 - There are some [limitations](../developer-guides/aa.md#limitations-of-the-verification-step) on this function.
 :::
 
-To increment the nonce, use the `incrementNonceIfEquals` function from the `NONCE_HOLDER_SYSTEM_CONTRACT` system contract. It takes the nonce of the transaction and checks whether it is the same as the provided one. If not, the transaction reverts; otherwise, the nonce increases.
+To increment the nonce, use the `incrementMinNonceIfEquals` function from the `NONCE_HOLDER_SYSTEM_CONTRACT` system contract. It takes the nonce of the transaction and checks whether it is the same as the provided one. If not, the transaction reverts; otherwise, the nonce increases.
 
 Even though the requirements above mean the accounts only touch their own storage slots, accessing your nonce in the `NONCE_HOLDER_SYSTEM_CONTRACT` is a [whitelisted](../developer-guides/aa.md#extending-the-set-of-slots-that-belong-to-a-user) case, since it behaves in the same way as your storage, it just happens to be in another contract. 
 


### PR DESCRIPTION
## Description of changes

Updates references and links, pointing to the updated function `incrementMinNonceIfEquals` from the previously mentioned `incrementNonceIfEquals`. As per the [INonceHolder interface](https://github.com/matter-labs/v2-testnet-contracts/blob/b8449bf9c819098cc8bfee0549ff5094456be51d/l2/system-contracts/interfaces/INonceHolder.sol#L13) and usage indicated in the AA tutorial [here](https://github.com/matter-labs/custom-aa-tutorial/blob/a56712817e9b7be617d7086b85f2a96c423437e0/contracts/TwoUserMultisig.sol#LL59C41-L59C66). 

Specifically, this PR includes the following updates:

- In `docs/dev/developer-guides/aa.md`, the reference to `incrementNonceIfEquals` has been updated to `incrementMinNonceIfEquals`.
- A link reference in `docs/dev/developer-guides/aa.md` previously pointing to [`INonceHolder` interface](https://github.com/matter-labs/v2-testnet-contracts/blob/b8449bf9c819098cc8bfee0549ff5094456be51d/l2/system-contracts/interfaces/INonceHolder.sol#L13) is now a permalink pointing to `incrementMinNonceIfEquals` signature.
- In `docs/dev/tutorials/custom-aa-tutorial.md`, references to `incrementNonceIfEquals` have been updated to `incrementMinNonceIfEquals`.
