### PR TITLE
Clarifying `EXTCODECOPY` entry

### DIFF
--- a/docs/dev/building-on-zksync/contracts/differences-with-ethereum.md
+++ b/docs/dev/building-on-zksync/contracts/differences-with-ethereum.md
@@ -171,9 +171,9 @@ Always produces a compile-time error with our toolchain.
 
 ### `EXTCODECOPY`
 
-Contract bytecode cannot be accessed in our architecture. Only its size is accessible with `CODESIZE` and `EXTCODESIZE`.
+Contract bytecode cannot be accessed in our architecture. Only its size is accessible with both `CODESIZE` and `EXTCODESIZE`.
 
-Always produces a compile-time error with our toolchain.
+`EXTCODECOPY` always produces a compile-time error with our toolchain.
 
 ### `DATASIZE`, `DATAOFFSET`, `DATACOPY`
 


### PR DESCRIPTION
-> Added a few clarifying words to avoid confusion in future.