### PR TITLE
Add private key best practices as a prerequisite

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -18,6 +18,7 @@ This is what we're going to do:
 - A wallet with sufficient Göerli `ETH` on L1 to pay for bridging funds to zkSync and deploying smart contracts.
 - ERC20 tokens on zkSync are required for the testnet paymaster. We recommend using [the faucet from the zkSync portal](https://goerli.portal.zksync.io/faucet).
 - You know [how to get your private key from your MetaMask wallet](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
+- You know [how to safely use your private key in your code](https://consensys.net/blog/developers/how-to-avoid-uploading-your-private-key-to-github-approaches-to-prevent-making-your-secrets-public/).
 
 ## Build and deploy the Greeter contract
 


### PR DESCRIPTION
We should include some documentation to make sure people follow best practices when using private keys to deploy their smart contracts. Optional could be to suggest to use a new account that will be utilized for testing purposes only