### PR TITLE
Updates vyper versions to supported versions

### DIFF
--- a/docs/tools/hardhat/hardhat-zksync-vyper.md
+++ b/docs/tools/hardhat/hardhat-zksync-vyper.md
@@ -37,20 +37,31 @@ This plugin most often will not be used directly in the code.
 ### Configuration
 
 ```typescript
-zkvyper: {
-  version: "1.3.10",
-  compilerSource: "binary",  // binary or docker
-  settings: {
-    compilerPath: "zkvyper",  // ignored for compilerSource: "docker"
-    libraries{} // optional. References to non-inlinable libraries
-
-  }
-}
-networks: {
-  hardhat: {
-    zksync: true  // enables zksync in hardhat local network
-  }
-}
+const config: HardhatUserConfig = {
+  zkvyper: {
+    version: "1.3.7",
+    compilerSource: "binary", // docker usage no longer recommended
+    settings: {
+      // compilerPath: "zkvyper", // optional field with the path to the `zkvyper` binary.
+      libraries: {}, // optional. References to non-inlinable libraries
+    },
+  },
+  defaultNetwork: "zkSyncTestnet",
+  networks: {
+    hardhat: {
+      zksync: true, // enables zksync in hardhat local network
+    },
+    zkSyncTestnet: {
+      url: "https://zksync2-testnet.zksync.dev",
+      ethNetwork: "goerli",
+      zksync: true,
+    },
+  },
+  // Currently, only Vyper ^0.3.3 is supported.
+  vyper: {
+    version: "0.3.3",
+  },
+};
 ```
 
 ::: warning


### PR DESCRIPTION
Changes introduced in this PR:

- Updates configuration to supported vyper versions based on releases found [here](https://github.com/matter-labs/zkvyper-bin/tree/main).

**Note:** I did need to compile the contracts using Rosetta to target `arch -x86_64` in order to compile successfully. Not sure if there is an issue detecting correct arch in the plugin [here](https://github.com/matter-labs/hardhat-zksync/blob/a218bed4be1ffc21aea38a129777555747c41b9e/packages/hardhat-zksync-vyper/src/utils.ts#L19) or with vyper directly. 