### PR TITLE
Update api3-usd-paymaster-tutorial.md

### DIFF
--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -60,7 +60,7 @@ cd ~/paymaster-dapi
 4. Add the project dependencies:
 
 ```sh
-yarn add -D @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable @api3/contracts
+yarn add -D @matterlabs/zksync-contracts @openzeppelin/contracts@4.6.0 @openzeppelin/contracts-upgradeable@4.6.0 @api3/contracts
 ```
 
 ## Design


### PR DESCRIPTION
The current version of the openzeppelin/contracts and openzeppelin/contracts-upgradeable, the v ^4.9.0 has peer dependencies issues with the packages: `@matterlabs/zksync-contracts` and the upgradeable plugin.

Just installing the peer depency, works.