### PR TITLE
chore: remove misleading refund comment

### DIFF
--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -161,7 +161,6 @@ contract MyPaymaster is IPaymaster {
         ExecutionResult _txResult,
         uint256 _maxRefundedGas
     ) external payable onlyBootloader override {
-        // Refunds are not supported yet.
     }
 
     receive() external payable {}
@@ -475,7 +474,6 @@ contract MyPaymaster is IPaymaster, Ownable {
         ExecutionResult _txResult,
         uint256 _maxRefundedGas
     ) onlyBootloader external payable override {
-        // Refunds are not supported yet.
     }
 
     receive() external payable {}

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -142,7 +142,6 @@ contract MyPaymaster is IPaymaster {
         ExecutionResult _txResult,
         uint256 _maxRefundedGas
     ) external payable onlyBootloader override {
-        // Refunds are not supported yet.
     }
 
     receive() external payable {}
@@ -356,7 +355,6 @@ contract MyPaymaster is IPaymaster {
         ExecutionResult _txResult,
         uint256 _maxRefundedGas
     ) external payable override onlyBootloader {
-        // Refunds are not supported yet.
     }
 
     receive() external payable {}

--- a/docs/reference/concepts/transactions/fee-model.md
+++ b/docs/reference/concepts/transactions/fee-model.md
@@ -95,10 +95,6 @@ The refund, therefore, returns the unpaid transaction fee portion to the user.
 
 Refunds are calculated by defining a fair value for the amount the user spent on the transaction and subtracting it from the actual spend.
 
-::: warning
-- Paymasters currently do not support refunds.
-:::
-
 ## Out-of-gas errors
 
 Unlike on Geth, it is impossible to track out-of-gas errors on zkSync Era. 


### PR DESCRIPTION
**Changes introduced in this PR:**
- Removes the "Refunds are not supported yet." comment and warning. 