### PR TITLE
adds Atlas to tutorials

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -21,6 +21,10 @@ This is what we're going to do:
 
 ## Build and deploy the Greeter contract
 
+::: info Project available in Atlas IDE
+You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/matter-labs/zksync-hardhat-template&open=Greeter.sol&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+:::
+
 ### Initialize the project
 
 1. Install the [zkSync CLI:](/docs/tools/zksync-cli/)

--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -22,7 +22,7 @@ This is what we're going to do:
 ## Build and deploy the Greeter contract
 
 ::: info Project available in Atlas IDE
-You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/matter-labs/zksync-hardhat-template&open=Greeter.sol&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+This entire tutorial can be run in under a minute using Atlas. Atlas is a smart contract IDE that lets you write, deploy, and interact with contracts from your browser. [Open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/matter-labs/zksync-hardhat-template&open=Greeter.sol&chainId=280).
 :::
 
 ### Initialize the project

--- a/docs/dev/tutorials/aa-daily-spend-limit.md
+++ b/docs/dev/tutorials/aa-daily-spend-limit.md
@@ -13,6 +13,15 @@ The daily limit feature prevents an account from spending more ETH than the limi
 - You know how to get your [private key from your MetaMask wallet](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
 - We encourage you to read [the basics of account abstraction on zkSync Era](../../reference/concepts/account-abstraction.md) and complete the [multisig account tutorial](./custom-aa-tutorial.md) before attempting this tutorial.
 
+
+## Complete Project
+
+Download the complete project [here](https://github.com/matter-labs/daily-spendlimit-tutorial). Additionally, the repository contains a test folder with more detailed tests for running on a zkSync Era local network.
+
+::: info Project available in Atlas IDE
+You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/Atlas-labs-inc/zksync-daily-spend-limit&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+:::
+
 ## Project set up
 
 We will use the [zkSync Era Hardhat plugins](../../tools/hardhat/) to build, deploy, and interact with the smart contracts in this project.
@@ -1040,10 +1049,6 @@ To keep this tutorial as simple as possible, we've used `block.timestamp` but we
 - Insufficient gasLimit: Transactions often fail due to insufficient gasLimit. Please increase the value manually when transactions fail without clear reasons.
 - Insufficient balance in account contract: transactions may fail due to the lack of balance in the deployed account contract. Please transfer funds to the account using MetaMask or `wallet.sendTransaction()` method used in `deploy/deployFactoryAccount.ts`.
 - Transactions submitted in a close range of time will have the same `block.timestamp` as they can be added to the same L1 batch and might cause the spend limit to not work as expected.
-
-## Complete Project
-
-Download the complete project [here](https://github.com/matter-labs/daily-spendlimit-tutorial). Additionally, the repository contains a test folder with more detailed tests for running on a zkSync Era local network.
 
 ## Learn more
 

--- a/docs/dev/tutorials/aa-daily-spend-limit.md
+++ b/docs/dev/tutorials/aa-daily-spend-limit.md
@@ -19,7 +19,7 @@ The daily limit feature prevents an account from spending more ETH than the limi
 Download the complete project [here](https://github.com/matter-labs/daily-spendlimit-tutorial). Additionally, the repository contains a test folder with more detailed tests for running on a zkSync Era local network.
 
 ::: info Project available in Atlas IDE
-You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/Atlas-labs-inc/zksync-daily-spend-limit&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+This entire tutorial can be run in under a minute using Atlas. Atlas is a smart contract IDE that lets you write, deploy, and interact with contracts from your browser. [Open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/Atlas-labs-inc/zksync-daily-spend-limit&open=/scripts/main.ts&chainId=280).
 :::
 
 ## Project set up

--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -26,15 +26,19 @@ Within a paymaster, price oracles provide price data on-chain for execution.
 
 For this paymaster tutorial, we use dAPIs to get the price of [ETH/USD](https://market.api3.org/dapis/zksync-goerli-testnet/ETH-USD) and [USDC/USD](https://market.api3.org/dapis/zksync-goerli-testnet/USDC-USD) datafeeds, and then calculate gas in USDC value so that users can pay for their transactions with USDC.
 
-::: note
+::: info
 
 - If you want to use an ERC20 token other than USDC, change the dAPIs used in the paymaster.
 - For example, if you want to use DAI, use the [DAI/USD](https://market.api3.org/dapis/zksync-goerli-testnet/DAI-USD) dAPI instead of USDC/USD.
   :::
 
-## Project repo
+## Complete project
 
 The tutorial code is available [here](https://github.com/vanshwassan/zk-paymaster-dapi-poc).
+
+::: info Project available in Atlas IDE
+You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-usdc-paymaster&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+:::
 
 ## Set up the project
 

--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -37,7 +37,7 @@ For this paymaster tutorial, we use dAPIs to get the price of [ETH/USD](https://
 The tutorial code is available [here](https://github.com/vanshwassan/zk-paymaster-dapi-poc).
 
 ::: info Project available in Atlas IDE
-You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-usdc-paymaster&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+This entire tutorial can be run in under a minute using Atlas. Atlas is a smart contract IDE that lets you write, deploy, and interact with contracts from your browser. [Open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-usdc-paymaster&open=/scripts/main.ts&chainId=280).
 :::
 
 ## Set up the project

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -19,7 +19,7 @@ This tutorial shows you how to build and deploy a 2-of-2 multi-signature account
 Download the complete project [here](https://github.com/matter-labs/custom-aa-tutorial).
 
 ::: info Project available in Atlas IDE
-You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-aa-multisig&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+This entire tutorial can be run in under a minute using Atlas. Atlas is a smart contract IDE that lets you write, deploy, and interact with contracts from your browser. [Open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-aa-multisig&open=/scripts/main.ts&chainId=280).
 :::
 
 ## Set up 

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -18,7 +18,11 @@ This tutorial shows you how to build and deploy a 2-of-2 multi-signature account
 
 Download the complete project [here](https://github.com/matter-labs/custom-aa-tutorial).
 
-## Set up
+::: info Project available in Atlas IDE
+You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-aa-multisig&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+:::
+
+## Set up 
 
 1. If you haven't already, install the [zkSync CLI:](/docs/tools/zksync-cli/)
 

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -23,7 +23,8 @@ This tutorial shows you how to build a custom paymaster that allows users to pay
 The tutorial code is available [here](https://github.com/matter-labs/custom-paymaster-tutorial).
 
 ::: info Project available in Atlas IDE
-You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-custom-paymaster&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+
+This entire tutorial can be run in under a minute using Atlas. Atlas is a smart contract IDE that lets you write, deploy, and interact with contracts from your browser. [Open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-custom-paymaster&open=/scripts/main.ts&chainId=280)
 :::
 
 ## Set up the project

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -18,9 +18,13 @@ This tutorial shows you how to build a custom paymaster that allows users to pay
   - [Gas estimation for transactions](../../reference/concepts/fee-model.md#gas-estimation-for-transactions) guide.
 - You should also know [how to get your private key from your MetaMask wallet](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key).
 
-## Project repo
+## Complete project
 
 The tutorial code is available [here](https://github.com/matter-labs/custom-paymaster-tutorial).
+
+::: info Project available in Atlas IDE
+You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-aa-multisig&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+:::
 
 ## Set up the project
 

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -23,7 +23,7 @@ This tutorial shows you how to build a custom paymaster that allows users to pay
 The tutorial code is available [here](https://github.com/matter-labs/custom-paymaster-tutorial).
 
 ::: info Project available in Atlas IDE
-You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-aa-multisig&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
+You can [open this project in Atlas](https://app.atlaszk.com/projects?template=https://github.com/atlas-labs-inc/zksync-custom-paymaster&open=/scripts/main.ts&chainId=280) to deploy the smart contracts and interact with them directly from your browser.
 :::
 
 ## Set up the project


### PR DESCRIPTION
# What :computer: 
Add message of tutorials available on Atlas

# Why :hand:
It simplifies the process of deploying contracts to Era

# Evidence :camera:
In Preview page 👇

## Comments
I'm running into issues with my metamask to run the scripts on Atlas as it crashes after the first transaction 🫤
