### PR TITLE
fix: cargo install command to add lock flag

### DIFF
--- a/docs/tools/testing/era-test-node.md
+++ b/docs/tools/testing/era-test-node.md
@@ -26,7 +26,7 @@ After checking all these prerequisites, you should be ready to use the `era-test
 Begin by installing `era-test-node` using the command:
 
 ```bash
-cargo install --git https://github.com/matter-labs/era-test-node.git
+cargo install --git https://github.com/matter-labs/era-test-node.git --locked
 ```
 
 Rust should install it in the `~/.cargo/bin` directory.


### PR DESCRIPTION
# What :computer: 
* Adds --locked flag to cargo install command for era-test-node which asserts installation from lock file.

# Why :hand:
* Build would fail when running `cargo install --git https://github.com/matter-labs/era-test-node.git`

# Evidence :camera:
```bash
Compiling sketches-ddsketch v0.2.1
error[E0631]: type mismatch in function arguments
   --> /Users/dennis/.cargo/git/checkouts/zksync-era-657998444dcd9ed9/e575ec1/core/lib/types/src/aggregated_operations.rs:82:52
    |
82  |                 Token::Array(proof.into_iter().map(Token::Uint).collect()),
    |                                                --- ^^^^^^^^^^^
    |                                                |   |
    |                                                |   expected due to this
    |                                                |   found signature defined here
    |                                                required by a bound introduced by this call
    |
    = note: expected function signature `fn(primitive_types::U256) -> _`
               found function signature `fn(zksync_basic_types::U256) -> _`
note: required by a bound in `std::iter::Iterator::map`
   --> /Users/dennis/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:803:12
    |
800 |     fn map<B, F>(self, f: F) -> Map<Self, F>
    |        --- required by a bound in this associated function
...
803 |         F: FnMut(Self::Item) -> B,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::map`

error[E0599]: the method `collect` exists for struct `Map<IntoIter<U256>, fn(U256) -> Token {zksync_basic_types::ethabi::Token::Uint}>`, but its trait bounds were not satisfied
  --> /Users/dennis/.cargo/git/checkouts/zksync-era-657998444dcd9ed9/e575ec1/core/lib/types/src/aggregated_operations.rs:82:65
   |
82 |                 Token::Array(proof.into_iter().map(Token::Uint).collect()),
   |                                                                 ^^^^^^^ method cannot be called due to unsatisfied trait bounds
   |
  ::: /Users/dennis/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:61:1
   |
61 | pub struct Map<I, F> {
   | -------------------- doesn't satisfy `_: Iterator`
   |
   = note: the following trait bounds were not satisfied:
           `<fn(zksync_basic_types::U256) -> Token {zksync_basic_types::ethabi::Token::Uint} as FnOnce<(primitive_types::U256,)>>::Output = _`
           which is required by `std::iter::Map<std::vec::IntoIter<primitive_types::U256>, fn(zksync_basic_types::U256) -> Token {zksync_basic_types::ethabi::Token::Uint}>: Iterator`
           `fn(zksync_basic_types::U256) -> Token {zksync_basic_types::ethabi::Token::Uint}: FnMut<(primitive_types::U256,)>`
           which is required by `std::iter::Map<std::vec::IntoIter<primitive_types::U256>, fn(zksync_basic_types::U256) -> Token {zksync_basic_types::ethabi::Token::Uint}>: Iterator`
           `std::iter::Map<std::vec::IntoIter<primitive_types::U256>, fn(zksync_basic_types::U256) -> Token {zksync_basic_types::ethabi::Token::Uint}>: Iterator`
           which is required by `&mut std::iter::Map<std::vec::IntoIter<primitive_types::U256>, fn(zksync_basic_types::U256) -> Token {zksync_basic_types::ethabi::Token::Uint}>: Iterator`

   Compiling anstyle-query v1.0.0
   Compiling tagptr v0.2.0
   Compiling urlencoding v2.1.3
   Compiling fake-simd v0.1.2
   Compiling colorchoice v1.0.0
   Compiling home v0.5.5
   Compiling opaque-debug v0.2.3
   Compiling triomphe v0.1.9
Some errors have detailed explanations: E0599, E0631.
For more information about an error, try `rustc --explain E0599`.
error: could not compile `zksync_types` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `era_test_node v1.0.2 (https://github.com/matter-labs/era-test-node.git#064a8eb0)`, intermediate artifacts can be found at `/var/folders/xk/93skcyt518l_b5sgpktx98vc0000gn/T/cargo-installO50Kuc`
```