### PR TITLE
Add Explanation on Bytecode Address Derivation

### DIFF
--- a/docs/reference/architecture/differences-with-ethereum.md
+++ b/docs/reference/architecture/differences-with-ethereum.md
@@ -75,6 +75,8 @@ export function createAddress(sender: Address, senderNonce: BigNumberish) {
 }
 ```
 
+Since the bytecode differs from Ethereum as zkSync uses a modified version of the EVM, the address derived from the bytecode hash will also differ. This means that the same bytecode deployed on Ethereum and zkSync will have different addresses and the Ethereum address will still be available and unused on zkSync. If and when the zkEVM reaches parity with the EVM, the address derivation will be updated to match Ethereum and the same bytecode will have the same address on both chains, deployed bytecodes to different addresses on zkSync could then be deployed to the same the Ethereum-matching addresses on zkSync.
+
 ### `CALL`, `STATICCALL`, `DELEGATECALL`
 
 For calls, you specify a memory slice to write the return data to, e.g. `out` and `outsize` arguments for


### PR DESCRIPTION
# What :computer: 
* Add extra text on bytecode address derivation difference between zkSync <> Ethereum

# Why :hand:
* To better understand why this difference is there

# Evidence :camera:

![image](https://github.com/matter-labs/zksync-web-era-docs/assets/10233439/fa179895-0c07-4249-ac98-f0836062592d)

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
