### PR TITLE
Update differences-with-ethereum.md

### DIFF
--- a/docs/reference/architecture/differences-with-ethereum.md
+++ b/docs/reference/architecture/differences-with-ethereum.md
@@ -199,7 +199,7 @@ contract Example {
 
     constructor() {
         assembly {
-            deployTimeCodeSize := codesize() // behaves as CALLDATASIZE
+            deployTimeCodeSize := codesize() // return the size of the constructor arguments
         }
     }
 


### PR DESCRIPTION
`CALLDATASIZE()` in constructor in EVM always returns zero (like `msg.data.length`). So, `codesize()` in constructor in zkEVM is not behaving like `CALLDATASIZE()` in constructor in EVM. The comment is misleading.
