### PR TITLE
fix: remove link to old tutorial repo

### DIFF
--- a/docs/tools/testing/dockerized-testing.md
+++ b/docs/tools/testing/dockerized-testing.md
@@ -200,4 +200,4 @@ yarn test
 
 Well done! You've successfully run your first local tests with zkSync Era.
 
-For a complete example with tests, check [here](https://github.com/matter-labs/tutorial-examples/tree/main/local-setup-testing)
+For a complete example with tests, check [here](https://github.com/matter-labs/tutorials/tree/main/hello-world)


### PR DESCRIPTION
# What :computer: 
* Update repo used for example test code

# Why :hand:
* The old repo has out-of-date dependencies and the tests are failing

# Evidence :camera:
Use link in comments
