### PR TITLE
feat: add vyper verification warnings, rename plugin

### DIFF
--- a/docs/.vuepress/sidebar/en.ts
+++ b/docs/.vuepress/sidebar/en.ts
@@ -188,6 +188,7 @@ export const enSidebar = sidebar({
             "/tools/hardhat/hardhat-zksync-deploy",
             "/tools/hardhat/hardhat-zksync-chai-matchers",
             "/tools/hardhat/hardhat-zksync-verify",
+            "/tools/hardhat/hardhat-zksync-verify-vyper",
             "/tools/hardhat/other-plugins",
           ],
         },

--- a/docs/tools/hardhat/getting-started.md
+++ b/docs/tools/hardhat/getting-started.md
@@ -16,6 +16,7 @@ zkSync Era has the following official plugins for Hardhat:
 - [@matterlabs/hardhat-zksync-deploy](./hardhat-zksync-deploy.md) - used to deploy smart contracts.
 - [@matterlabs/hardhat-zksync-chai-matchers](./hardhat-zksync-chai-matchers.md) - adds zkSync-specific capabilities to the [Chai](https://www.chaijs.com/) assertion library for testing smart contracts.
 - [@matterlabs/hardhat-zksync-verify](./hardhat-zksync-verify.md) - used to verify smart contracts.
+- [@matterlabs/hardhat-zksync-verify-vyper](./hardhat-zksync-verify-vyper.md) - used to verify vyper smart contracts.
 - [@matterlabs/hardhat-zksync-upgradable](./hardhat-zksync-upgradable.md) - used to deploy, update, and verify proxy smart contracts.
 
 ::: tip Additional plugins

--- a/docs/tools/hardhat/hardhat-zksync-verify-vyper.md
+++ b/docs/tools/hardhat/hardhat-zksync-verify-vyper.md
@@ -1,0 +1,167 @@
+# `hardhat-zksync-verify-vyper`
+
+This plugin is used to verify vyper contracts on the zkSync Era network.
+
+:::warning Verification context
+Current version of the verify vyper plugin has a limitation where in order to verify the vyper contract, verification request must be sent with exactly the same vyper smart contracts list in your project's "contracts" folder, as it was during the deployment of that specific vyper contract.<br>
+
+This means that if you had both `VyperGreeterOne.vy` and `VyperGreeterTwo.vy` smart contracts in your project when you deployed them, in order to verify each one of them separately, you will also need to have both of them in the project when sending verification request. In any other situation, you will receive a message that contract's "bytecode doesn't match any of your local contracts".<br>
+
+In order to minimize this risk, we <i><b>strongly</b></i> recommend you to verify your vyper smart contracts right after their deployment!<br>
+
+:::
+
+:::warning Alpha release
+
+Because of verification context limitation, hardhat-zksync-verify-vyper plugin is still labeled as `alpha` and we do NOT recommend using it in the production environment. On the other hand, we are working on removing this limitation and we want to encourage you to give us your feedback on the plugin's functionalities, usability or possible improvements. Please start or engage in the discussion about it in our [Community Hub](https://github.com/zkSync-Community-Hub/zkync-developers/discussions), or open a Github issue in the [project's repository](https://github.com/matter-labs/hardhat-zksync/issues).
+
+:::
+
+## Setup
+
+The [@matterlabs/hardhat-zksync-verify-vyper](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-verify-vyper) plugin is used to verify contracts on zkSync network.
+To use it, install plugin and then import `@matterlabs/hardhat-zksync-verify-vyper` in the `hardhat.config.ts` file.
+
+::: code-tabs
+
+@tab:active yarn
+
+```bash
+yarn add -D @matterlabs/hardhat-zksync-verify-vyper
+```
+
+@tab npm
+
+```bash
+npm i -D @matterlabs/hardhat-zksync-verify-vyper
+```
+
+:::
+
+### Configuration
+
+Import the plugin in the `hardhat.config.ts` file:
+
+```javascript
+import "@matterlabs/hardhat-zksync-verify-vyper";
+```
+
+Add the `verifyURL` property to the zkSync Era network in the `hardhat.config.ts` file as shown below:
+
+```typescript
+networks: {
+    goerli: {
+      url: "https://goerli.infura.io/v3/<API_KEY>" // The Ethereum Web3 RPC URL (optional).
+    },
+    zkTestnet: {
+      url: "https://testnet.era.zksync.dev", // The testnet RPC URL of zkSync Era network.
+      ethNetwork: "goerli", // The Ethereum Web3 RPC URL, or the identifier of the network (e.g. `mainnet` or `goerli`)
+      zksync: true,
+      // Verification endpoint for Goerli
+      verifyURL: 'https://zksync2-testnet-explorer.zksync.dev/contract_verification'
+    }
+},
+// defaultNetwork: "zkTestnet", // optional (if not set, use '--network zkTestnet')
+```
+
+Additional network properties:
+
+- `zkTestnet` is an arbitrary zkSync Era network name. You can select this as the default network using the `defaultNetwork` property.
+- `url` is a field with the URL of the zkSync Era node. This field is required for all zkSync networks used by this plugin.
+- `ethNetwork` is a field with the URL of the Ethereum node. You can also provide network name (e.g. `goerli`) as the value of this field. In this case, the plugin will either use the URL of the appropriate Ethereum network configuration (from the `networks` section), or the default `ethers` provider for the network if the configuration is not provided. This field is required for all zkSync networks used by this plugin.
+- `zksync` is a flag that indicates a zkSync Era network configuration. This field is set to `true` for all zkSync Era networks. Field value `true` is required for this plugin work. If field is missing or if values is set to `false` plugin will throw a error.
+- `verifyURL` is a field that points to the verification endpoint for the specific zkSync network. This parameter is optional, and its default value is the testnet verification url.
+  - Testnet: `https://zksync2-testnet-explorer.zksync.dev/contract_verification`
+  - Mainnet: `https://zksync2-mainnet-explorer.zksync.io/contract_verification`
+
+### Commands
+
+```sh
+yarn hardhat verify:vyper --network <network> <contract address>
+```
+
+This command verifies the contract on the given network with the given contract's address. <br/>
+When executed in this manner, the verification task attempts to compare the compiled bytecode of all the contracts in your local environment with the deployed bytecode of the contract you are seeking to verify. If there is no match, it reports an error.
+
+```sh
+yarn hardhat verify:vyper --network <network> <contract address> --contract <fully qualified name>
+```
+
+With the `--contract` parameter you can also specify which contract from your local setup you want to verify by specifying its Fully qualified name. Fully qualified name structure looks like this: "contracts/Contract.vy:Contract" <br/>
+
+#### Constructor arguments
+
+If your contract was deployed with specific constructor arguments, you need to specify them when running the verify task. For example:
+
+```sh
+yarn hardhat verify:vyper --network testnet 0x7cf08341524AAF292255F3ecD435f8EE1a910AbF "Hi there!"
+```
+
+If your constructor takes a complex argument list, you can write a separate Javascript module to export it. For example, create an `arguments.js` file with the following structure:
+
+```typescript
+module.exports = [
+  "a string argument",
+  "0xabcdef",
+  "42",
+  {
+    property1: "one",
+    property2: 2,
+  },
+];
+```
+
+Include it in the verify function call by adding a new parameter: `--constructor-args arguments.js`:
+
+```sh
+yarn hardhat verify:vyper --network testnet 0x7cf08341524AAF292288F3ecD435f8EE1a910AbF --constructor-args arguments.js
+```
+
+The hardhat-zksync-verify plugin also supports the verification with encoded constructor parameters.
+
+In order to use the encoded parameters, you need to specify a separate javascript module and export them as a <b>_non-array_</b> parameter.
+It is important for encoded arguments to start with `0x` in order to be recognized by the plugin. For example:
+
+```typescript
+module.exports = "0x0x00087a676164696a61310000087a676164696a61310000000000000000000000008537b364a83f5c9a7ead381d3baf9cbb83769bf5";
+```
+
+### Verification status check
+
+The verification process consists of two steps:
+
+- A verification request is sent to confirm if the given parameters for your contract are correct.
+- Then, we check the verification status of that request.
+  Both steps run when you run the `verify:vyper` task, but you will be able to see your specific verification request ID.
+  You can then use this ID to check the status of your verification request without running the whole process from the beginning.
+
+The following command checks the status of the verification request for the specific verification ID:
+
+```sh
+yarn hardhat verify-status:vyper --verification-id <your verification id>
+```
+
+### Verify smart contract programmatically
+
+If you need to run the verification task directly from your code, you can use the hardhat `verify:verify:vyper` task with the previously mentioned parameters.
+
+```typescript
+const verificationId = await hre.run("verify:verify:vyper", {
+  address: contractAddress,
+  contract: contractFullyQualifedName,
+  constructorArguments: [...]
+});
+```
+
+This task returns a verification id if the request was successfully sent.<br/>
+You can use this id to check the status of your verification request as described in the section above.
+
+If you are using encoded constructor args, `constructorArguments` parameter should be a non-array value starting with `0x`.
+
+```typescript
+const verificationId = await hre.run("verify:verify:vyper", {
+  address: contractAddress,
+  contract: contractFullyQualifedName,
+  constructorArguments: "0x12345...",
+});
+```

--- a/docs/tools/hardhat/plugins.md
+++ b/docs/tools/hardhat/plugins.md
@@ -18,6 +18,7 @@ List of official plugins:
 - [hardhat-zksync-deploy](./hardhat-zksync-deploy.md)
 - [hardhat-zksync-chai-matchers](./hardhat-zksync-chai-matchers.md)
 - [hardhat-zksync-verify](./hardhat-zksync-verify.md)
+- [hardhat-zksync-verify-vyper](./hardhat-zksync-verify-vyper.md)
 - [hardhat-zksync-upgradable](./hardhat-zksync-upgradable.md)
 
 ::: tip Popular Hardhat plugins


### PR DESCRIPTION
# What :computer: 
* Renamed hardhat-zksync-vyper-verify to hardhat-zksync-verfiy-vyper
* Added verification context warning for the verify-vyper plugin
* Added alpha release warning for the verify-vyper plugin

# Why :hand:
* Incompatibility between plugin's name and its commands
* A feature of the zkvyper compiler to produce different contract bytecode depending of project's contracts context

# Evidence :camera:
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/117362319/ef841163-d28d-4b0f-b499-0f87c56fde15)

