### PR TITLE
Add a warning on rate limiting

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -19,7 +19,7 @@ zkSync Era supports the standard [Ethereum JSON-RPC API](https://ethereum.org/en
 
 :::warning Rate Limits
 
-We apply rate limiting to both Https and Websocket apis. The limits are generally permissive (currently 10s to 100s RPS per client), but please contact us if you face any issues in that regard.
+We apply rate limiting to both HTTPs and Websocket APIs. The limits are generally permissive (currently 10s to 100s RPS per client), but please contact us if you face any issues in that regard.
 
 ### Testnet
 

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -17,6 +17,10 @@ zkSync Era supports the standard [Ethereum JSON-RPC API](https://ethereum.org/en
 
 ## RPC endpoint URLs
 
+:::warning Rate Limits
+
+We apply rate limiting to both Https and Websocket apis. The limits are generally permissive (currently 10s to 100s RPS per client), but please contact us if you face any issues in that regard.
+
 ### Testnet
 
 - HTTPS: `https://testnet.era.zksync.dev`

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -19,7 +19,8 @@ zkSync Era supports the standard [Ethereum JSON-RPC API](https://ethereum.org/en
 
 :::warning Rate Limits
 
-We apply rate limiting to both HTTPs and Websocket APIs. The limits are generally permissive (currently 10s to 100s RPS per client), but please contact us if you face any issues in that regard.
+We apply rate limiting to both HTTPS and Websocket APIs. The limits are generally permissive (currently 10s to 100s RPS per client), but please contact us if you face any issues in that regard.
+:::
 
 ### Testnet
 

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -19,7 +19,7 @@ zkSync Era supports the standard [Ethereum JSON-RPC API](https://ethereum.org/en
 
 :::warning Rate Limits
 
-We apply rate limiting to both HTTPS and Websocket APIs. The limits are generally permissive (currently 10s to 100s RPS per client), but please contact us if you face any issues in that regard.
+We apply rate limiting to both HTTPS and Websocket APIs. The limits are generally permissive (currently 10s to 100s RPS per client), but please [contact us](https://github.com/zkSync-Community-Hub/zkync-developers/discussions) if you face any issues in that regard.
 :::
 
 ### Testnet


### PR DESCRIPTION
# What :computer: 
Added a note on rate limiting the https and websocket API

# Why :hand:
We introduced a permissive rate limiting on websocket. http api is limited on cloudflare side

# Notes :memo:
* Please have a look at the wording and whether we should add more details
