### PR TITLE
Point to Tutorials Repo for Dockerized Set Up

### DIFF
--- a/docs/tools/testing/dockerized-testing.md
+++ b/docs/tools/testing/dockerized-testing.md
@@ -200,4 +200,4 @@ yarn test
 
 Well done! You've successfully run your first local tests with zkSync Era.
 
-For a complete example with tests, check [here](https://github.com/matter-labs/tutorial-examples/tree/main/local-setup-testing)
+For a complete example of a Hello World project set up with tests following this Dockerized setup, check [here](https://github.com/matter-labs/tutorials/tree/main/hello-world-docker)


### PR DESCRIPTION
# What :computer: 
* Changes link to monorepo tutorials example for Dockerized setup

# Why :hand:
* Old link was pointing to unmaintained repo. 

# Evidence :camera:
<img width="753" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/10233439/2cb2bba9-26a9-403c-8425-5bdbc7911848">

