### PR TITLE
qa: feedback session changes for Verify Contracts with Hardhat tutorial

### DIFF
--- a/docs/dev/how-to/verify-contracts.md
+++ b/docs/dev/how-to/verify-contracts.md
@@ -31,13 +31,13 @@ For open-source projects, verifying contracts enhances trust and encourages more
 
 ### 1. Project setup
 
-- Begin by installing [zkSync CLI](../../tools/zksync-cli/README.md) to establish a new project:
+1. Begin by installing [zkSync CLI](../../tools/zksync-cli/README.md) to establish a new project:
 
 ```sh
 yarn add global zksync-cli@latest
 ```
 
-- Once you complete the installation, execute the command below to create a fresh project:
+2. Once you complete the installation, execute the command below to create a fresh project:
 
 ```sh
 zksync-cli create-project verify-greeter-contract
@@ -133,7 +133,11 @@ yarn hardhat compile
 
 The [zkSync CLI](../../tools/zksync-cli/README.md) provides a `deploy/deploy-greeter.ts` script that we will use to deploy the Greeter contract.
 
-Add your private key to `<WALLET-PRIVATE-KEY>` in the `.env.example` file and remove `.example`.
+To configure your private key, copy the `.env.example` file, rename the copy to `.env`, and add your wallet private key.
+
+```text
+WALLET_PRIVATE_KEY=abcdef12345....
+```
 
 Initiate contract deployment using this command:
 
@@ -295,4 +299,4 @@ Once this script runs, it prints the verification ID. If the verification reques
 
 ### 9. UI block explorer alternative
 
-Contract verification in zkSync Era ensures the integrity and trustworthiness of your contracts. The [zkSync Era Block Explorer](https://explorer.zksync.io/blocks/) is a manual UI process for doing the same, ideal for occasional use, while the `hardhat-zksync-verify` plugin facilitates an automated, flexible approach for developers.
+Contract verification in zkSync Era ensures the integrity and trustworthiness of your contracts. The [Smart Contract Verification in zkSync Era Block Explorer](https://explorer.zksync.io/contracts/verify) is a manual UI process for doing the same, ideal for occasional use, while the `hardhat-zksync-verify` plugin facilitates an automated, flexible approach for developers.


### PR DESCRIPTION
Step "1. Project setup" - aligned list style to numbers (previously both bullet list and numbers were present)
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/4accde6c-48f3-49e3-9258-dc42b48fafe3)

Step "5. Deploy the Greeter contract" - replaced instruction to rename the file to more obvious one from[ "Hello world" tutorial](https://era.zksync.io/docs/dev/building-on-zksync/hello-world.html#initialize-the-project)
<img width="1166" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/bf5bbba6-af21-4c09-9b5d-c0b33a2d7129">


Step "9. UI block explorer alternative" - fixed with correct link https://explorer.zksync.io/contracts/verify to "Smart Contract Verification" page
<img width="1127" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/58cd90a9-1640-44c7-ba9e-0146dc3ded6a">

# Notes :memo:
All the added fixes based on the [feedback Notion doc ](https://www.notion.so/matterlabs/Verify-Contracts-with-Hardhat-tutorial-QA-feedback-3022dfd2915840d3a95e5b5f43459633)
