### PR TITLE
qa: feedback session changes for Daily spending limit account tutorial

### DIFF
--- a/docs/dev/tutorials/aa-daily-spend-limit.md
+++ b/docs/dev/tutorials/aa-daily-spend-limit.md
@@ -942,7 +942,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 
   // account that will receive the ETH transfer
   const receiver = "<RECEIVER_ACCOUNT>";
-  // ⚠️ update this amount to test if the limit works; 0.00051 fails but 0.0049 succeeds
+  // ⚠️ update this amount to test if the limit works; 0.00051 fails but 0.00049 succeeds
   const transferAmount = "0.00051";
 
   let ethTransferTx = {
@@ -1020,7 +1020,7 @@ An unexpected error occurred:
 Error: transaction failed...
 ```
 
-After the error, we can rerun the code with a different ETH amount that doesn't exceed the limit, say "0.0049", to see if the `SpendLimit` contract doesn't refuse the amount lower than the limit.
+After the error, we can rerun the code with a different ETH amount that doesn't exceed the limit, say "0.00049", to see if the `SpendLimit` contract doesn't refuse the amount lower than the limit.
 
 If the transaction succeeds, the output should look something like this:
 
@@ -1064,4 +1064,4 @@ To keep this tutorial as simple as possible, we've used `block.timestamp` but we
 
 ## Credits
 
-Written by [porco-rosso](https://linktr.ee/porcorossoj) for the following [GitCoin bounty](https://gitcoin.co/issue/29669).
+Written by [porco-rosso](https://linktr.ee/porcorossoj) for the GitCoin bounty.


### PR DESCRIPTION
Step "Perform ETH transfer" - fixed incorrect "0.0049" amount to correct "0.00049" 
<img width="1171" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/efc47d9e-741a-44d1-81ea-ac69183f2406">

Step "Credits" - removed incorrect external "GitCoin bounty" link
<img width="1171" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/4ec9a292-5c92-433c-b21a-1f7b866161c6">


# Notes :memo:
* All the added fixes based on the [Daily spending limit account - QA feedback Notion doc](https://www.notion.so/matterlabs/Daily-spending-limit-account-QA-feedback-5decf66447e240ec8a0f4ef98c901428)
