### PR TITLE
qa: "Transfer a token on L2" tutorials PR fix

### DIFF
--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -574,6 +574,7 @@ echo 'PRIVATE_KEY=' > .env
 ### 3. Compile and deploy
 
 From the project root, run the following:
+<delete>
 
 ```sh
 yarn hardhat compile


### PR DESCRIPTION
[ERROR] ❌ Result of runningyarn ts-node transfer-l2.ts command:

```
artem@Artems-MacBook-Pro transfer-l2 % yarn ts-node transfer-l2.ts                          
yarn run v1.22.19
warning package.json: No license field
$ /Users/artem/node_modules/.bin/ts-node transfer-l2.ts
node:internal/modules/cjs/loader:959
  throw err;
  ^

Error: Cannot find module './transfer-l2.ts'
Require stack:
- /Users/artem/imaginaryUncacheableRequireResolveScript
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:956:15)
    at Function.resolve (node:internal/modules/cjs/helpers:108:19)
    at requireResolveNonCached (/Users/artem/node_modules/ts-node/dist/bin.js:549:16)
    at getProjectSearchDir (/Users/artem/node_modules/ts-node/dist/bin.js:519:40)
    at phase3 (/Users/artem/node_modules/ts-node/dist/bin.js:267:27)
    at bootstrap (/Users/artem/node_modules/ts-node/dist/bin.js:47:30)
    at main (/Users/artem/node_modules/ts-node/dist/bin.js:33:12)
    at Object.<anonymous> (/Users/artem/node_modules/ts-node/dist/bin.js:579:5)
    at Module._compile (node:internal/modules/cjs/loader:1126:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/artem/imaginaryUncacheableRequireResolveScript' ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```