### PR TITLE
qa: feedback session changes for Transfer a token on L2 tutorial

### DIFF
--- a/docs/dev/how-to/transfer-token-l2.md
+++ b/docs/dev/how-to/transfer-token-l2.md
@@ -153,8 +153,12 @@ l2transfer();
 ## Run the script
 
 ```sh
-yarn ts-node transfer-l2.ts
+ts-node transfer-l2.ts
 ```
+
+:::tip
+Try running the `ts-node transfer-l2.ts` command in case you receive an error with `yarn ts-node transfer-l2.ts`.
+:::
 
 ## Output
 

--- a/docs/dev/how-to/transfer-token-l2.md
+++ b/docs/dev/how-to/transfer-token-l2.md
@@ -153,7 +153,7 @@ l2transfer();
 ## Run the script
 
 ```sh
-ts-node transfer-l2.ts
+yarn ts-node transfer-l2.ts
 ```
 
 :::tip


### PR DESCRIPTION
Added a tip to run `ts-node transfer-l2.ts` instead of `yarn ts-node transfer-l2.ts`
<img width="671" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/18f332fd-1232-48a5-b266-9177ed136346">

# Notes :memo:
* All the added fixes based on the ["Transfer a token on L2" tutorial QA feedback Notion doc](https://www.notion.so/matterlabs/Transfer-a-token-on-L2-tutorial-QA-feedback-93300817e0c64dff859b00661394717d)
