### PR TITLE
Update doc to include STOP and modify the comment in RETURN example

### DIFF
--- a/docs/reference/architecture/differences-with-ethereum.md
+++ b/docs/reference/architecture/differences-with-ethereum.md
@@ -126,10 +126,10 @@ If the `offset` for `calldataload(offset)` is greater than `2^32-33` then execut
 Internally on zkEVM, `calldatacopy(to, offset, len)` there is just a loop with the `calldataload` and `mstore` on each iteration.
 That means that the code will panic if `2^32-32 + offset % 32 < offset + len`.
 
-### `RETURN`
+### `RETURN`, `STOP`
 
-Constructors return the array of immutable values. If you use `RETURN` in an assembly block in the constructor on zkSync Era,
-it will return the array of immutable values initialized so far.
+Constructors return the array of immutable values. If you use `RETURN` or `STOP` in an assembly block in the constructor on zkSync Era,
+it will leave the immutable variables uninitialized.
 
 ```solidity
 contract Example {
@@ -139,9 +139,14 @@ contract Example {
         x = 45;
 
         assembly {
-            // The statement below is overridden by the zkEVM compiler to return
-            // the array of immutables instead of 32 bytes specified by the user.
-            return(0, 32)
+            // The statements below are overridden by the zkEVM compiler to return
+            // the array of immutables.
+
+            // The statement below leaves the variable x uninitialized.
+            // return(0, 32)
+
+            // The statement below leaves the variable x uninitialized.
+            // stop()
         }
     }
 


### PR DESCRIPTION
Using `RETURN` or `STOP` in assembly block in the constructor will left the immutable variables uninitialized.

# What :computer: 
* First thing updated with this PR
* Second thing updated with this PR
* Third thing updated with this PR

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
