### PR TITLE
fix: redstone tutorial missing links

### DIFF
--- a/docs/dev/community-tutorials/redstone-marketplace-tutorial.md
+++ b/docs/dev/community-tutorials/redstone-marketplace-tutorial.md
@@ -106,7 +106,7 @@ We've used hardhat test framework to contract tests. All the tests are located i
 
 ```sh
 git clone https://github.com/zkSync-Community-Hub/tutorials
-cd tutorials/tutorials/zkSync-RedStone-stable-price-marketplace-tutorial
+cd tutorials/tutorials/zkSync-RedStone-stable-price-marketplace-tutorial/code
 ```
 
 #### 2. Install dependencies

--- a/docs/dev/community-tutorials/redstone-marketplace-tutorial.md
+++ b/docs/dev/community-tutorials/redstone-marketplace-tutorial.md
@@ -11,7 +11,7 @@ By the end of this tutorial you will understand how to integrate your dApp built
 
 ## Example dApp - Stable price NFT marketplace
 
-This repo is designed to show how to build a dApp that uses [RedStone oracles](https://redstone.finance/) on [zkSync](https://zksync.io/).
+[This repo](https://github.com/zkSync-Community-Hub/tutorials/tree/main/tutorials/zkSync-RedStone-stable-price-marketplace-tutorial/code) is designed to show how to build a dApp that uses [RedStone oracles](https://redstone.finance/) on [zkSync](https://zksync.io/).
 
 The repo contains an implementation of an NFT marketplace dApp with so-called "stable" price. It means that sellers can create sell orders (offers), specifying the price amount in USD. But buyers are able to pay with native coins, the required amount of which is calculated dynamically at the moment of the order execution. Repo lacks few crucial parts which will demonstrate how to integrate RedStone oracles and deploy dApp on zkSync Era Testnet.
 


### PR DESCRIPTION
# What :computer: 
* Fixes cd command to go one level lower
* Adds link to tutorial repo in text 

# Why :hand:
* cd was leading to higher level readme only
