### PR TITLE
fix: yarn command for global installation of zksync-cli

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -41,7 +41,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. Install the [zkSync CLI:](../../tools/zksync-cli/README.md)
 
 ```sh
-yarn add global zksync-cli@latest
+yarn global add zksync-cli@latest
 ```
 
 2. Scaffold a new project by running the command:


### PR DESCRIPTION
# What :computer: 
* Installation command to install the `zksync-cli` globally using the `yarn` package manager

# Why :hand:
* The command mentioned in [docs](https://era.zksync.io/docs/dev/building-on-zksync/hello-world.html#initialize-the-project) was `yarn add global zksync-cli@latest` which is not the correct way to install packages globally, it installs the `zksync-cli` as a dependency local to the current project which essentially invalidates using the command `zksync-cli` as it is not installed globally.
<img width="1307" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/145468656/ac057f89-d5be-45df-b2ce-d90c0ca3ba35">


# Evidence :camera:
The fix is to simply use the correct command `yarn global add zksync-cli@latest`. 

<img width="1339" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/145468656/275d4a19-4d4a-4475-90ec-d854d70a185b">



<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->
