### PR TITLE
fix: yarn command for global installation of zksync-cli

### DIFF
--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -39,7 +39,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. If you haven't already, install the [zkSync CLI:](../../tools/zksync-cli/README.md)
 
 ```sh
-yarn add global zksync-cli@latest
+yarn global add zksync-cli@latest
 ```
 
 2. Initiate a new project by running the command:


### PR DESCRIPTION
# What :computer: 
* Installation command to install the `zksync-cli` globally using the `yarn` package manager. The issue and fix both are the same as in issue #724 

# Why :hand:
* The command mentioned in [docs for creating a custom paymaster](https://era.zksync.io/docs/dev/building-on-zksync/hello-world.html#initialize-the-project) was `yarn add global zksync-cli@latest` which is not the correct way to install packages globally. Please see issue #724 for more details.


# Evidence :camera:
Please see issue #724 for more details.



<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->
