### PR TITLE
fix: zksync cli commands restructure

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -45,7 +45,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. Scaffold a new project by running the command:
 
 ```sh
-npx zksync-cli create-project greeter-example --template hardhat_solidity
+npx zksync-cli create project greeter-example --template hardhat_solidity
 ```
 
 This creates a new zkSync Era project called `greeter-example` with a basic `Greeter` contract and all the zkSync plugins and configurations.

--- a/docs/dev/community-tutorials/zksync-cli-quickstart.md
+++ b/docs/dev/community-tutorials/zksync-cli-quickstart.md
@@ -25,7 +25,7 @@ Without needing testnet ETH, `zksync-cli` allows testing contracts locally. Use 
 Execute the following code to create a new project named `quickstart` using an existing template.
 
 ```sh
-npx zksync-cli create-project quickstart --template hardhat_solidity  && cd quickstart
+npx zksync-cli create project quickstart --template hardhat_solidity  && cd quickstart
 ```
 
 Inside `quickstart`, you’ll find:

--- a/docs/dev/how-to/verify-contracts.md
+++ b/docs/dev/how-to/verify-contracts.md
@@ -34,7 +34,7 @@ For open-source projects, verifying contracts enhances trust and encourages more
 1. Scaffold a new project by running the command:
 
 ```sh
-npx zksync-cli create-project verify-greeter-contract --template hardhat_solidity
+npx zksync-cli create project verify-greeter-contract --template hardhat_solidity
 ```
 
 This creates a new zkSync Era project called `verify-greeter-contract` with a basic `Greeter` contract and all the zkSync plugins and configurations.

--- a/docs/dev/tutorials/aa-daily-spend-limit.md
+++ b/docs/dev/tutorials/aa-daily-spend-limit.md
@@ -45,7 +45,7 @@ We will use the [zkSync Era Hardhat plugins](../../tools/hardhat/) to build, dep
 1. Initiate a new project by running the command:
 
 ```sh
-npx zksync-cli create-project custom-spendlimit-tutorial --template hardhat_solidity
+npx zksync-cli create project custom-spendlimit-tutorial --template hardhat_solidity
 ```
 
 :::tip

--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -62,7 +62,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 2. Run the following command to create a new project:
 
 ```sh
-npx zksync-cli create-project paymaster-dapi --template hardhat_solidity
+npx zksync-cli create project paymaster-dapi --template hardhat_solidity
 ```
 
 This creates a new zkSync Era project called `paymaster-dapi` with a basic `Greeter` contract.

--- a/docs/dev/tutorials/cross-chain-tutorial.md
+++ b/docs/dev/tutorials/cross-chain-tutorial.md
@@ -242,7 +242,7 @@ Now that we have an address for the L1 governance contract, we can build, deploy
 1. `cd` into `/L2-counter` and initialize the project:
 
 ```sh
-npx zksync-cli create-project . --template hardhat_solidity
+npx zksync-cli create project . --template hardhat_solidity
 ```
 
 ::: tip

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -38,7 +38,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. Initiate a new project by running the command:
 
 ```sh
-npx zksync-cli create-project custom-aa-tutorial --template hardhat_solidity
+npx zksync-cli create project custom-aa-tutorial --template hardhat_solidity
 ```
 
 :::tip

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -39,7 +39,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. Initiate a new project by running the command:
 
 ```sh
-npx zksync-cli create-project custom-paymaster-tutorial --template hardhat_solidity
+npx zksync-cli create project custom-paymaster-tutorial --template hardhat_solidity
 ```
 
 :::tip

--- a/docs/reference/concepts/bridging-asset.md
+++ b/docs/reference/concepts/bridging-asset.md
@@ -154,7 +154,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 }
 ```
 
-To run this script, configure your `hardhat.config.ts` file as explained in this [guide](../../tools/hardhat/hardhat-zksync-deploy.md), or use the command `npx zksync-cli create-project PROJECT_NAME` to scaffold a new project.
+To run this script, configure your `hardhat.config.ts` file as explained in this [guide](../../tools/hardhat/hardhat-zksync-deploy.md), or use the command `npx zksync-cli create project PROJECT_NAME` to scaffold a new project.
 
 Once your `hardhat.config.ts` file is configured, place the script files in the `deploy` folder and run them with the following command:
 

--- a/docs/tools/hardhat/getting-started.md
+++ b/docs/tools/hardhat/getting-started.md
@@ -58,7 +58,7 @@ Skip the hassle for test ETH by using `zksync-cli` for local testing. Simply exe
 To create a new project run the CLI's `create` command, passing a project name:
 
 ```sh
-npx zksync-cli create-project demo --template hardhat_solidity
+npx zksync-cli create project demo --template hardhat_solidity
 ```
 
 This command creates a `demo` folder and clones a Hardhat template project inside it. The downloaded project is already configured and contains all the required plugins.

--- a/docs/tools/hardhat/hardhat-zksync-vyper.md
+++ b/docs/tools/hardhat/hardhat-zksync-vyper.md
@@ -36,7 +36,7 @@ Skip the hassle for test ETH by using `zksync-cli` for local testing. Simply exe
 Use the [zkSync Era cli](../../tools/zksync-cli/README.md) to set up a project.
 
 ```sh
-npx zksync-cli@latest create-project greeter-vyper-example --template hardhat_vyper
+npx zksync-cli@latest create project greeter-vyper-example --template hardhat_vyper
 cd greeter-vyper-example
 ```
 

--- a/docs/tools/zksync-cli/README.md
+++ b/docs/tools/zksync-cli/README.md
@@ -70,7 +70,7 @@ Create projects with these templates using `zksync-cli create project`:
 
 ### 🔗 Supported Chains
 
-zkSync CLI supports Era Testnet and Era Mainnet by default. Use other networks by overriding L1 and L2 RPC URLs: `zksync-cli deposit --l2-rpc=http://... --l1-rpc=http://...`
+zkSync CLI supports Era Testnet and Era Mainnet by default. Use other networks by overriding L1 and L2 RPC URLs: `zksync-cli bridge deposit --l2-rpc=http://... --l1-rpc=http://...`
 
 For using [local setup (dockerized testing node)](../testing/dockerized-testing.md) with default RPC URLs, select `Local Dockerized node` in CLI or use `--chain local-dockerized`.
 

--- a/docs/tools/zksync-cli/README.md
+++ b/docs/tools/zksync-cli/README.md
@@ -20,7 +20,7 @@ Ensure you have the following installed:
 - [Node.js v18+](https://nodejs.org/en)
 - [Git](https://git-scm.com/downloads)
 - [Docker](https://www.docker.com/get-started/) (required for `zksync-cli dev` commands)
-- [Yarn](https://v3.yarnpkg.com/getting-started/install) (required for `zksync-cli create-project`)
+- [Yarn](https://v3.yarnpkg.com/getting-started/install) (required for `zksync-cli create project`)
 
 ### Installation and Usage
 
@@ -45,9 +45,9 @@ Run `zksync-cli help dev` for more commands and details.
 ### Other Essential Commands
 
 - **Basic Operations**:
-  - `zksync-cli create-project {FOLDER_NAME}`: Creates a project in a specified folder.
-  - `zksync-cli deposit`: Moves funds from Ethereum (L1) to zkSync (L2).
-  - `zksync-cli withdraw` and `zksync-cli withdraw-finalize`: Manage funds withdrawal from zkSync (L2) to Ethereum (L1).
+  - `zksync-cli create project {FOLDER_NAME}`: Creates a project in a specified folder.
+  - `zksync-cli bridge deposit`: Moves funds from Ethereum (L1) to zkSync (L2).
+  - `zksync-cli bridge withdraw` and `zksync-cli bridge withdraw-finalize`: Manage funds withdrawal from zkSync (L2) to Ethereum (L1).
 - **Help & Info**:
   - `zksync-cli help`: General help.
   - `zksync-cli help {command}`: Detailed command usage info.
@@ -63,7 +63,7 @@ More commands and updates are coming! If you have suggestions, [open an issue on
 
 ### Project Templates
 
-Create projects with these templates using `zksync-cli create-project`:
+Create projects with these templates using `zksync-cli create project`:
 
 - [Hardhat + Solidity](https://github.com/matter-labs/zksync-hardhat-template).
 - [Hardhat + Vyper](https://github.com/matter-labs/zksync-hardhat-vyper-template).


### PR DESCRIPTION
# What :computer: 
* Update zkSync CLI documentation according to the command restructure from https://github.com/matter-labs/zksync-cli/pull/64

# Why :hand:
* Make docs up-to-date with latest version of zkSync CLI

# Evidence :camera:
<img width="723" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/47187316/b83a24b4-da49-43d5-93f6-c38a8881e848">

# Notes :memo:
* Should be merged with [zkSync CLI PR](https://github.com/matter-labs/zksync-cli/pull/64)
