### PR TITLE
fix: correct link for IZkSync Interface link

### DIFF
--- a/docs/dev/how-to/send-transaction-l1-l2.md
+++ b/docs/dev/how-to/send-transaction-l1-l2.md
@@ -20,7 +20,7 @@ Along with zkSync Era's built-in censorship resistance that requires multi-layer
 
 1. Import the zkSync Era library or contract containing the required functionality.
 
-   The import gives access to the [`IZkSync.sol`](https://github.com/matter-labs/era-contracts/blob/b8449bf9c819098cc8bfee0549ff5094456be51d/l1/contracts/zksync/interfaces/IZkSync.sol#L4) inherited interfaces that include the gas estimation functionality.
+   The import gives access to the [`IZkSync.sol`](https://github.com/matter-labs/v2-testnet-contracts/blob/b8449bf9c819098cc8bfee0549ff5094456be51d/l1/contracts/zksync/interfaces/IZkSync.sol#L4) inherited interfaces that include the gas estimation functionality.
 
    Import the contracts with yarn (recommended), or [download the contracts](https://github.com/matter-labs/v2-testnet-contracts) from the repo.
 


### PR DESCRIPTION
# What :computer: 
- Updated the `/tools/hardhat/getting-started.md` to fix the link of [IZSync](https://era.zksync.io/docs/dev/how-to/send-transaction-l1-l2.html#step-by-step) to the era contracts.

# Why :hand:
- Because it was linking into a bad request

# Evidence :camera:
<img width="1259" alt="Screenshot 2023-10-09 at 16 38 47" src="https://github.com/matter-labs/zksync-web-era-docs/assets/22985657/8851e198-980a-4e59-bb24-f471c94dc937">

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* All good
