### PR TITLE
fix: firebase source to redirect at github link tutorial

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -322,6 +322,11 @@
           "source": "/docs/api/tools{,/**}",
           "destination": "/docs/tools/",
           "type": "302"
+        },
+        {
+          "source": "/docs/dev/community-tutorials/the-graph-tutorial.html",
+          "destination": "https://github.com/zkSync-Community-Hub/tutorials/blob/main/tutorials/the-graph/TUTORIAL.md",
+          "type": "302"
         }
       ]
     },
@@ -646,6 +651,11 @@
         {
           "source": "/docs/api/tools{,/**}",
           "destination": "/docs/tools/",
+          "type": "302"
+        },
+        {
+          "source": "/docs/dev/community-tutorials/the-graph-tutorial.html",
+          "destination": "https://github.com/zkSync-Community-Hub/tutorials/blob/main/tutorials/the-graph/TUTORIAL.md",
           "type": "302"
         }
       ]


### PR DESCRIPTION
# What :computer: 
- Google search for "the graph zksync" showed up this link https://era.zksync.io/docs/dev/community-tutorials/the-graph-tutorial.html which is 404; 
- fix it by redirecting it to here https://github.com/zkSync-Community-Hub/tutorials/blob/main/tutorials/the-graph/TUTORIAL.md

# Why :hand:
- broken link: https://era.zksync.io/docs/dev/community-tutorials/the-graph-tutorial.html

