### PR TITLE
fix: add info block cli block explorer

### DIFF
--- a/docs/tools/testing/README.md
+++ b/docs/tools/testing/README.md
@@ -54,7 +54,7 @@ Whether you're testing new contracts, debugging transactions, or prototyping, zk
 
 ## Using zkSync CLI for Easy Setup
 
-The [zkSync CLI](../zksync-cli/README.md) makes it simple for developers to work with both Dockerized Local Setup and In-Memory Node. Just use `zksync-cli dev start` to get your local development environment running and choose to use additional modules like Wallet and Bridge if you need them.
+The [zkSync CLI](../zksync-cli/README.md) makes it simple for developers to work with both Dockerized Local Setup and In-Memory Node. Just use `zksync-cli dev start` to get your local development environment running and choose to use additional modules like Block Explorer, Wallet and Bridge.
 
 ## zkSync Era local testing
 

--- a/docs/tools/zksync-cli/README.md
+++ b/docs/tools/zksync-cli/README.md
@@ -32,7 +32,7 @@ Or
 
 ## Highlight: Start Developing Locally, Fast
 
-Use `zksync-cli dev` for an easy way to work with zkSync on your computer. It helps you set up and manage local zkSync and Ethereum nodes, Wallet, and Bridge without hassle.
+Use `zksync-cli dev` for an easy way to work with zkSync on your computer. It helps you set up and manage local zkSync and Ethereum nodes, Block Explorer, Wallet, and Bridge without hassle.
 
 ### Quick ‘dev’ Commands
 


### PR DESCRIPTION
# What :computer: 
* Added info about Block Explorer for zkSync CLI

# Why :hand:
* To let users know that they can easily start Block Explorer locally with zkSync CLI
