### PR TITLE
chore: format nested bullets

### DIFF
--- a/docs/dev/how-to/send-message-l2-l1.md
+++ b/docs/dev/how-to/send-message-l2-l1.md
@@ -83,7 +83,10 @@ function proveL2MessageInclusion(
 
 - `_blockNumber`: L1 batch number in which the L2 block was included; retrievable using the `getBlock` method.
 - `_index`: Index of the L2 log in the block; returned as `id` by the [`zks_getL2ToL1LogProof`](../../api/api.md#zks-getl2tol1logproof) method.
-  `_message`: Parameter holding the message data. It should be an object containing: - `sender`: Address that sent the message from L2. - `data`: Message sent in bytes. - `txNumberInBlock`: Index of the transaction in the L2 block; returned as `transactionIndex` with [`getTransactionReceipt`](https://docs.ethers.org/v5/single-page/#/v5/api/providers/provider/-%23-Provider-getTransactionReceipt) on an Ethers `Provider` object.
+- `_message`: Parameter holding the message data. It should be an object containing: 
+  - `sender`: Address that sent the message from L2. 
+  - `data`: Message sent in bytes. 
+  - `txNumberInBlock`: Index of the transaction in the L2 block; returned as `transactionIndex` with [`getTransactionReceipt`](https://docs.ethers.org/v5/single-page/#/v5/api/providers/provider/-%23-Provider-getTransactionReceipt) on an Ethers `Provider` object.
 - `_proof`: Merkle proof of the message inclusion; retrieved by observing Ethereum or using the `zks_getL2ToL1LogProof` method of the zksync-web3 API.
   :::
 


### PR DESCRIPTION
# What :computer: 
* Markdown formatting for nested bullets in the parameter details sections for [Send an L2 to L1 message docs](https://era.zksync.io/docs/dev/how-to/send-message-l2-l1.html#prove-the-result)

# Why :hand:
* A bit easier and clearer to read

# Evidence :camera:
### Before
<img width="969" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/145468656/bcbbdc6e-a2ec-441a-84fb-744d6b8d957e">

### After
<img width="803" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/145468656/b7540469-ce2e-4ffe-a333-4684d0da8875">
