### PR TITLE
chore: remove duplicate rust sdk from dev tools

### DIFF
--- a/docs/assets/data/devtools.json
+++ b/docs/assets/data/devtools.json
@@ -18,13 +18,6 @@
           "url": "https://era.zksync.io/docs/api/python"
         },
         {
-          "name": "Rust SDK",
-          "category": "SDK",
-          "description": "Extends ethers-rs including zksync-specific methods and utilities.",
-          "logo": "rust-logo.svg",
-          "url": "https://github.com/lambdaclass/zksync-web3-rs"
-        },
-        {
           "name": "Go SDK",
           "category": "SDK",
           "description": "Extends go-ethereum including zksync-specific methods and utilities.",


### PR DESCRIPTION
# What :computer: 
* Remove duplicate Rust SDK from Dev Tools

# Why :hand:
* Causing confusion. Kept the one that links to the Docs and not directly to the GitHub repo.

# Evidence :camera:
Only 1 Rust SDK in the list:
<img width="753" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/1890113/0b37ec54-8fe5-40e1-8cf9-603ac48b3ac0">

