### PR TITLE
chore: remove zkSync Portal mention

### DIFF
--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -573,7 +573,7 @@ The wallet had 3 tokens after running the deployment script and, after sending t
 
 ## Common errors
 
-- If the `use-paymaster.ts` script fails with the error `Failed to submit transaction: Failed to validate the transaction. Reason: Validation revert: Paymaster validation error: Failed to transfer tx fee to the bootloader. Paymaster balance might not be enough.`, please try sending additional ETH to the paymaster so it has enough funds to pay for the transaction. You can use [zkSync Portal](https://goerli.portal.zksync.io/).
+- If the `use-paymaster.ts` script fails with the error `Failed to submit transaction: Failed to validate the transaction. Reason: Validation revert: Paymaster validation error: Failed to transfer tx fee to the bootloader. Paymaster balance might not be enough.`, please try sending additional ETH to the paymaster so it has enough funds to pay for the transaction. You can use [zkSync native bridge or ecosystem partners](https://zksync.io/explore#bridges) (make sure Goerli testnet supported by selected bridge).
 - If the `use-paymaster.ts` script fails when minting new ERC20 tokens with the error `Error: transaction failed`, and the transactions appear with status "Failed" in the [zkSync explorer](https://explorer.zksync.io/), please reach out to us on [our Discord](https://join.zksync.dev/). As a workaround, try including a specific `gasLimit` value in the transaction.
 
 ## Learn more


### PR DESCRIPTION
# What :computer: 
* Removed zkSync Portal mention - replaced it by Bridges https://zksync.io/explore#bridges page

# Why :hand:
* We have obsolete zkSync Portal mention  in a doc
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/14a281ff-63f3-43a6-a7c0-34c553f4d5c4)


# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
