### PR TITLE
chore: add devxp team as additional owners of repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @matter-labs/product
+* @matter-labs/product @matter-labs/devxp


### PR DESCRIPTION
# What :computer: 
* Add `devxp` team as additional owners of repo

# Why :hand:
* The `product` team does not encompass the full team responsible for a lot of content in these docs
