### PR TITLE
chore: update Safe URL

### DIFF
--- a/docs/assets/data/devtools.json
+++ b/docs/assets/data/devtools.json
@@ -182,10 +182,10 @@
           "url": "https://layerzero.network/"
         },
         {
-          "name": "Safe (Protofire)",
+          "name": "Safe",
           "category": "Custody",
           "logo": "safe-logo.png",
-          "url": "https://zksafe.protofire.io/welcome"
+          "url": "https://app.safe.global/welcome"
         },
         {
           "name": "Snapshot",


### PR DESCRIPTION
# What :computer: 
* updated Safe URL to https://app.safe.global/welcome since recently zkSync Era was officially added to app.safe.global and Protofire finished its support

# Why :hand:
* Outdated Protofire link
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/cc44b642-1056-49c1-b278-877e34d869f9)
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/d5dcc487-7345-494d-a5f9-72565ac4330e)


# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
