### PR TITLE
fix: improve examples releated to deployment in `zksync2-js`

### DIFF
--- a/docs/api/js/zksync2-js/examples/create.md
+++ b/docs/api/js/zksync2-js/examples/create.md
@@ -35,11 +35,9 @@ async function main() {
   const bytecode: string = conf.contracts["Storage.sol:Storage"].bin;
 
   const factory = new ContractFactory(abi, bytecode, wallet);
-  const contract = await factory.deploy();
-  const contractAddress = await contract.getAddress();
-  console.log(`Contract address: ${contractAddress}`);
+  const storage = (await factory.deploy()) as Contract;
+  console.log(`Contract address: ${await storage.getAddress()}`);
 
-  const storage = new Contract(contractAddress, abi, wallet);
   console.log(`Value: ${await storage.get()}`);
 
   const tx = await storage.set(Typed.uint256(200));
@@ -71,11 +69,9 @@ async function main() {
   const bytecode: string = conf.contracts["Incrementer.sol:Incrementer"].bin;
 
   const factory = new ContractFactory(abi, bytecode, wallet);
-  const contract = await factory.deploy(2);
-  const contractAddress = await contract.getAddress();
-  console.log(`Contract address: ${contractAddress}`);
+  const incrementer = (await factory.deploy(2)) as Contract;
+  console.log(`Contract address: ${await incrementer.getAddress()}`);
 
-  const incrementer = new Contract(contractAddress, abi, wallet);
   console.log(`Value before Increment method execution: ${await incrementer.get()}`);
 
   const tx = await incrementer.increment();
@@ -107,13 +103,11 @@ async function main() {
   const bytecode: string = conf.contracts["Demo.sol:Demo"].bin;
 
   const factory = new ContractFactory(abi, bytecode, wallet);
-  const contract = await factory.deploy({
+  const demo = (await factory.deploy({
     customData: { factoryDeps: [conf.contracts["Foo.sol:Foo"].bin] },
-  });
-  const contractAddress = await contract.getAddress();
-  console.log(`Contract address: ${contractAddress}`);
+  })) as Contract;
+  console.log(`Contract address: ${await demo.getAddress()}`);
 
-  const demo = new Contract(contractAddress, abi, wallet);
   console.log(`Value: ${await demo.getFooName()}`);
 }
 

--- a/docs/api/js/zksync2-js/examples/create2.md
+++ b/docs/api/js/zksync2-js/examples/create2.md
@@ -34,13 +34,11 @@ async function main() {
   const bytecode: string = conf.contracts["Storage.sol:Storage"].bin;
 
   const factory = new ContractFactory(abi, bytecode, wallet, "create2");
-  const contract = await factory.deploy({
+  const storage = (await factory.deploy({
     customData: { salt: ethers.hexlify(ethers.randomBytes(32)) },
-  });
-  const contractAddress = await contract.getAddress();
-  console.log(`Contract address: ${contractAddress}`);
+  })) as Contract;
+  console.log(`Contract address: ${await storage.getAddress()}`);
 
-  const storage = new Contract(contractAddress, abi, wallet);
   console.log(`Value: ${await storage.get()}`);
 
   const tx = await storage.set(Typed.uint256(200));
@@ -72,13 +70,11 @@ async function main() {
   const bytecode: string = conf.contracts["Incrementer.sol:Incrementer"].bin;
 
   const factory = new ContractFactory(abi, bytecode, wallet, "create2");
-  const contract = await factory.deploy(2, {
+  const incrementer = (await factory.deploy(2, {
     customData: { salt: ethers.hexlify(ethers.randomBytes(32)) },
-  });
-  const contractAddress = await contract.getAddress();
-  console.log(`Contract address: ${contractAddress}`);
+  })) as Contract;
+  console.log(`Contract address: ${await incrementer.getAddress()}`);
 
-  const incrementer = new Contract(contractAddress, abi, wallet);
   console.log(`Value before Increment method execution: ${await incrementer.get()}`);
 
   const tx = await incrementer.increment();
@@ -110,16 +106,14 @@ async function main() {
   const bytecode: string = conf.contracts["Demo.sol:Demo"].bin;
 
   const factory = new ContractFactory(abi, bytecode, wallet, "create2");
-  const contract = await factory.deploy({
+  const demo = (await factory.deploy({
     customData: {
       salt: ethers.hexlify(ethers.randomBytes(32)),
       factoryDeps: [conf.contracts["Foo.sol:Foo"].bin],
     },
-  });
-  const contractAddress = await contract.getAddress();
-  console.log(`Contract address: ${contractAddress}`);
+  })) as Contract;
+  console.log(`Contract address: ${await demo.getAddress()}`);
 
-  const demo = new Contract(contractAddress, abi, wallet);
   console.log(`Value: ${await demo.getFooName()}`);
 }
 

--- a/docs/api/js/zksync2-js/examples/custom-paymaster/deploy-account.md
+++ b/docs/api/js/zksync2-js/examples/custom-paymaster/deploy-account.md
@@ -28,8 +28,7 @@ async function main() {
 
   const factory = new ContractFactory(abi, bytecode, wallet, "createAccount");
   const account = await factory.deploy(tokenAddress);
-  const accountAddress = await account.getAddress();
-  console.log(`Account address: ${accountAddress}`);
+  console.log(`Account address: ${await account.getAddress()}`);
 }
 
 main()
@@ -60,8 +59,7 @@ async function main() {
   const account = await factory.deploy(tokenAddress, {
     customData: { salt: ethers.hexlify(ethers.randomBytes(32)) },
   });
-  const accountAddress = await account.getAddress();
-  console.log(`Account address: ${accountAddress}`);
+  console.log(`Account address: ${await account.getAddress()}`);
 }
 
 main()

--- a/docs/api/js/zksync2-js/examples/custom-paymaster/deploy-token.md
+++ b/docs/api/js/zksync2-js/examples/custom-paymaster/deploy-token.md
@@ -25,11 +25,10 @@ async function main() {
   const bytecode: string = conf.bytecode;
 
   const factory = new ContractFactory(abi, bytecode, wallet);
-  const contract = await factory.deploy("Crown", "Crown", 18);
-  const tokenAddress = await contract.getAddress();
+  const token = (await factory.deploy("Crown", "Crown", 18)) as Contract;
+  const tokenAddress = await token.getAddress();
   console.log(`Contract address: ${tokenAddress}`);
 
-  const token = new Contract(tokenAddress, abi, wallet);
   const tx = await token.mint(Typed.address(await wallet.getAddress()), Typed.uint256(10));
   await tx.wait();
   console.log(`Crown tokens: ${await wallet.getBalance(tokenAddress)}`);
@@ -58,13 +57,12 @@ async function main() {
   const bytecode: string = conf.bytecode;
 
   const factory = new ContractFactory(abi, bytecode, wallet, "create2");
-  const contract = await factory.deploy("Crown", "Crown", 18, {
+  const token = (await factory.deploy("Crown", "Crown", 18, {
     customData: { salt: ethers.hexlify(ethers.randomBytes(32)) },
-  });
-  const tokenAddress = await contract.getAddress();
+  })) as Contract;
+  const tokenAddress = await token.getAddress();
   console.log(`Contract address: ${tokenAddress}`);
 
-  const token = new Contract(tokenAddress, abi, wallet);
   const tx = await token.mint(Typed.address(await wallet.getAddress()), Typed.uint256(10));
   await tx.wait();
   console.log(`Crown tokens: ${await wallet.getBalance(tokenAddress)}`);


### PR DESCRIPTION
# What :computer: 
* Improve examples related to account and contract deployment in `zksync2-js`.

# Why :hand:
* There is no create separate `ethers.Contract` after the account/contract is deployed with `ContractFactory.deploy`. Account/contract that is returned by `ContractFactory.deploy` can be used as well.