### PR TITLE
fix: remove zks_getTokenPrice docs

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -739,40 +739,6 @@ curl -X POST -H "Content-Type: application/json" \
 }
 ```
 
-### `zks_getTokenPrice`
-
-Returns the price of a given token in USD.
-
-:::tip Note
-
-- The price used by the zkSync Era team may be a bit different to the current market price.
-- On testnets, token prices are often different from the actual market price.
-  :::
-
-#### Inputs
-
-| Parameter | Type      | Description               |
-| --------- | --------- | ------------------------- |
-| address   | `address` | The address of the token. |
-
-#### curl example
-
-```curl
-curl -X POST -H "Content-Type: application/json" \
---data '{"jsonrpc": "2.0", "id": 1, "method": "zks_getTokenPrice", "params": [ "0x0000000000000000000000000000000000000000" ]}' \
-"https://mainnet.era.zksync.io"
-```
-
-#### Output
-
-```json
-{
-  "jsonrpc": "2.0",
-  "result": "1908.42",
-  "id": 1
-}
-```
-
 ### `zks_getTransactionDetails`
 
 Returns data from a specific transaction given by the transaction hash.

--- a/docs/api/java/providers.md
+++ b/docs/api/java/providers.md
@@ -155,29 +155,6 @@ public class Main {
 | ------- | ------------------------------- |
 | returns | Prepared get paymaster request. |
 
-### `zksGetTokenPrice`
-
-Get price of the token in USD.
-
-Example:
-
-```java
-import io.zksync.protocol.ZkSync;
-import org.web3j.protocol.http.HttpService;
-
-public class Main {
-    public static void main(String ...args) {
-      ZksTokenPrice response = zksync.zksGetTokenPrice(ETH.getL2Address()).send();
-}
-```
-
-#### Inputs and outputs
-
-| Name         | Description                       |
-| ------------ | --------------------------------- |
-| tokenAddress | Address of the token in hex.      |
-| returns      | Prepared get token price request. |
-
 ### `zksGetTransactionReceipt`
 
 Get transaction receipt. The same as `eth_getTransactionReceipt` but with additional fields belong to L2toL1Log

--- a/docs/api/js/providers.md
+++ b/docs/api/js/providers.md
@@ -573,26 +573,6 @@ const provider = new Provider("https://testnet.era.zksync.dev");
 console.log(await provider.getTestnetPaymasterAddress());
 ```
 
-### `getTokenPrice` DEPRECATED
-
-::: warning Deprecated
-
-- This method is deprecated and will be removed in the near future.
-  :::
-
-Returns the USD price for a token. Please note that this is the price that is used by the zkSync team and can be a bit different from the current market price. On testnets, token prices can be very different from the actual market price.
-
-Calls the [`zks_getTokenPrice`](../api.md#zks-gettokenprice) JSON-RPC method.
-
-#### Example
-
-```typescript
-import { Provider } from "zksync-web3";
-const provider = new Provider("https://testnet.era.zksync.dev");
-
-console.log(await provider.getTokenPrice(USDC_L2_ADDRESS));
-```
-
 ### `getTransaction`
 
 Returns a specified L2 transaction response object by overriding the [Ethers implementation](https://docs.ethers.org/v5/api/providers/provider/#Provider-getTransaction).


### PR DESCRIPTION
# What :computer: 
- removed zks_getTokenPrice docs
- removed getTokenPrice SDKs methods docs

# Why :hand:
- zks_getTokenPrice will no longer be supported, it replaced with explorer APIs

# Evidence :camera:
<img width="1217" alt="Screenshot 2023-11-03 at 15 12 36" src="https://github.com/matter-labs/zksync-web-era-docs/assets/8478134/9dd8c56c-1eff-4778-80e5-e0ccf6dfc75c">

