### PR TITLE
Clarify L1 and L2 address when bridging assets

### DIFF
--- a/docs/reference/concepts/bridging-asset.md
+++ b/docs/reference/concepts/bridging-asset.md
@@ -40,6 +40,7 @@ Users must call the `deposit` method on the L1 bridge contract, which triggers t
 - The L1 bridge initiates a transaction to the L2 bridge using L1 -> L2 communication.
 - Within the L2 transaction, tokens will be minted and sent to the specified address on L2.
   - If the token does not exist on zkSync yet, a new contract is deployed for it. Given the L2 token address is deterministic (based on the original L1 address, name and symbol), it doesn't matter who is the first person bridging it, the new L2 address will be the same.
+  - The L2 token address is not guaranteed to be the same with the L1 token address. The [ContractDeployer](../architecture/system-contracts.md#contractdeployer) system contract will emit a `ContractDeployed` event with the new L2 token address.
 - For every executed L1 -> L2 transaction, there will be an L2 -> L1 log message confirming its execution.
 - Lastly, the `finalizeDeposit`method is called and it finalizes the deposit and mints funds on L2.
 


### PR DESCRIPTION
# What :computer: 
* Updated the `bridging-asset.md` page to clarify that when a new token is created on the L2 bridge, its address will not be the same with the L1's token contract address

# Why :hand:
I will include my full line of thought:

While reading the docs, I got confused about the `If the token does not exist on zkSync yet, a new contract is deployed for it. Given the L2 token address is deterministic (based on the original L1 address, name and symbol), it doesn't matter who is the first person bridging it, the new L2 address will be the same.` section. At first glance, I assumed it meant that the L1 token address will be the same as the L2 address, in a permissionless manner, and it didn't make much sense: how can the L2 guarantee such a thing, maybe the token contract address was nonce derived on L1, and since all contracts on L2 are created using `create2` the Bridge contract must have some "magic power" to write code to any address, even if an ERC20 bridge should have no special powers. I assumed zkSync Era had a new special UX feature like this. After reading it a few more times and asking around in the Discord channel, it became clear that `the new L2 address will be the same.` just means that the token on L2 will always be deployed to the same address, which does make sense, but that doesn't mean it's going to be the same to the L1 address.

Maybe changing the wording or adding another line to clarify this will spare future readers from some confusion. 

# Evidence :camera:
![Screenshot 2023-11-06 062729](https://github.com/matter-labs/zksync-web-era-docs/assets/32748771/15a29939-f668-44de-b66d-b3b3c607efab)

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* If you think the wording is not quite right, any improvement would be appreciated.
