### PR TITLE
chore: remove depredated Telegram support group link

### DIFF
--- a/docs/reference/troubleshooting/docs-contribution/docs.md
+++ b/docs/reference/troubleshooting/docs-contribution/docs.md
@@ -13,7 +13,7 @@ Contributing to any large project necessitates collaboration among project membe
 
 As collaboration on contribution to zkSync documentation is such an integral part of the community, there are many ways to communicate with others doing the same and to learn from them:
 
-- Instant messaging tools, such as [zkSync Discord](https://join.zksync.dev/), [Telegram: user support group](https://t.me/zksync_support).
+- Instant messaging tool, such as [zkSync Discord](https://join.zksync.dev/).
 - Issues - Communicate about actionable items (things that can be acted upon and completed, such as problems with a specific Documentation page, a need for reorganization, etc.):
   - If you find a problem with a specific page in the zkSync documentation, you can always [edit the page](#edit-or-review-a-documentation-page) to fix it.
   - If you want to discuss a larger problem or propose a major change to the zkSync documentation, you can raise an [issue on Github](https://github.com/matter-labs/zksync-web-v2-docs/issues).


### PR DESCRIPTION
# What :computer: 
* Removed depredated Telegram support group link mentioned in "Contribute to documents" doc - the group has been deprecated earlier this year
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/112873874/a27e55ff-7f9d-4f91-828d-4f148f30d529)

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
