### PR TITLE
fix: update cli docs according to new cli update

### DIFF
--- a/cspell-zksync.txt
+++ b/cspell-zksync.txt
@@ -74,6 +74,8 @@ zkforge
 zkcast
 Eigen
 IPFS
+Nuxt
+viem
 
 // Used programming language words
 printf

--- a/cspell.json
+++ b/cspell.json
@@ -29,7 +29,9 @@
     "misc",
     "fullstack",
     "softwareTerms",
-    "zksync"
+    "zksync",
+    "nuxt",
+    "viem"
 ],
 "dictionaryDefinitions": [
     {

--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -45,7 +45,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. Scaffold a new project by running the command:
 
 ```sh
-npx zksync-cli create project greeter-example --template hardhat_solidity
+npx zksync-cli create greeter-example --template hardhat_solidity
 ```
 
 This creates a new zkSync Era project called `greeter-example` with a basic `Greeter` contract and all the zkSync plugins and configurations.

--- a/docs/dev/how-to/send-message-l2-l1.md
+++ b/docs/dev/how-to/send-message-l2-l1.md
@@ -256,9 +256,9 @@ function proveL2MessageInclusion(
 
 - `_blockNumber`: L1 batch number in which the L2 block was included; retrievable using the `getBlock` method.
 - `_index`: Index of the L2 log in the block; returned as `id` by the [`zks_getL2ToL1LogProof`](../../api/api.md#zks-getl2tol1logproof) method.
-- `_message`: Parameter holding the message data. It should be an object containing: 
-  - `sender`: Address that sent the message from L2. 
-  - `data`: Message sent in bytes. 
+- `_message`: Parameter holding the message data. It should be an object containing:
+  - `sender`: Address that sent the message from L2.
+  - `data`: Message sent in bytes.
   - `txNumberInBlock`: Index of the transaction in the L2 block; returned as `transactionIndex` with [`getTransactionReceipt`](https://docs.ethers.org/v5/single-page/#/v5/api/providers/provider/-%23-Provider-getTransactionReceipt) on an Ethers `Provider` object.
 - `_proof`: Merkle proof of the message inclusion; retrieved by observing Ethereum or using the `zks_getL2ToL1LogProof` method of the zksync-web3 API.
   :::

--- a/docs/dev/how-to/verify-contracts.md
+++ b/docs/dev/how-to/verify-contracts.md
@@ -34,7 +34,7 @@ For open-source projects, verifying contracts enhances trust and encourages more
 1. Scaffold a new project by running the command:
 
 ```sh
-npx zksync-cli create project verify-greeter-contract --template hardhat_solidity
+npx zksync-cli create verify-greeter-contract --template hardhat_solidity
 ```
 
 This creates a new zkSync Era project called `verify-greeter-contract` with a basic `Greeter` contract and all the zkSync plugins and configurations.

--- a/docs/dev/tutorials/aa-daily-spend-limit.md
+++ b/docs/dev/tutorials/aa-daily-spend-limit.md
@@ -45,7 +45,7 @@ We will use the [zkSync Era Hardhat plugins](../../tools/hardhat/) to build, dep
 1. Initiate a new project by running the command:
 
 ```sh
-npx zksync-cli create project custom-spendlimit-tutorial --template hardhat_solidity
+npx zksync-cli create custom-spendlimit-tutorial --template hardhat_solidity
 ```
 
 :::tip

--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -62,7 +62,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 2. Run the following command to create a new project:
 
 ```sh
-npx zksync-cli create project paymaster-dapi --template hardhat_solidity
+npx zksync-cli create paymaster-dapi --template hardhat_solidity
 ```
 
 This creates a new zkSync Era project called `paymaster-dapi` with a basic `Greeter` contract.

--- a/docs/dev/tutorials/cross-chain-tutorial.md
+++ b/docs/dev/tutorials/cross-chain-tutorial.md
@@ -242,7 +242,7 @@ Now that we have an address for the L1 governance contract, we can build, deploy
 1. `cd` into `/L2-counter` and initialize the project:
 
 ```sh
-npx zksync-cli create project . --template hardhat_solidity
+npx zksync-cli create . --template hardhat_solidity
 ```
 
 ::: tip

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -38,7 +38,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. Initiate a new project by running the command:
 
 ```sh
-npx zksync-cli create project custom-aa-tutorial --template hardhat_solidity
+npx zksync-cli create custom-aa-tutorial --template hardhat_solidity
 ```
 
 :::tip

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -39,7 +39,7 @@ This entire tutorial can be run in under a minute using Atlas. Atlas is a smart 
 1. Initiate a new project by running the command:
 
 ```sh
-npx zksync-cli create project custom-paymaster-tutorial --template hardhat_solidity
+npx zksync-cli create custom-paymaster-tutorial --template hardhat_solidity
 ```
 
 :::tip

--- a/docs/reference/concepts/bridging-asset.md
+++ b/docs/reference/concepts/bridging-asset.md
@@ -154,7 +154,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 }
 ```
 
-To run this script, configure your `hardhat.config.ts` file as explained in this [guide](../../tools/hardhat/hardhat-zksync-deploy.md), or use the command `npx zksync-cli create project PROJECT_NAME` to scaffold a new project.
+To run this script, configure your `hardhat.config.ts` file as explained in this [guide](../../tools/hardhat/hardhat-zksync-deploy.md), or use the command `npx zksync-cli create --template hardhat_solidity` to scaffold a new project.
 
 Once your `hardhat.config.ts` file is configured, place the script files in the `deploy` folder and run them with the following command:
 

--- a/docs/tools/hardhat/getting-started.md
+++ b/docs/tools/hardhat/getting-started.md
@@ -58,7 +58,7 @@ Skip the hassle for test ETH by using `zksync-cli` for local testing. Simply exe
 To create a new project run the CLI's `create` command, passing a project name:
 
 ```sh
-npx zksync-cli create project demo --template hardhat_solidity
+npx zksync-cli create demo --template hardhat_solidity
 ```
 
 This command creates a `demo` folder and clones a Hardhat template project inside it. The downloaded project is already configured and contains all the required plugins.

--- a/docs/tools/zksync-cli/README.md
+++ b/docs/tools/zksync-cli/README.md
@@ -24,34 +24,30 @@ Ensure you have the following installed:
 
 ### Installation and Usage
 
-- Run commands directly with NPX: `npx zksync-cli {COMMAND}`
-
-Or
-
-- Install globally with npm: `npm install -g zksync-cli` and then use: `zksync-cli {COMMAND}`
+You can run commands without installation: `npx zksync-cli`. For example: `npx zksync-cli dev start`.
 
 ## Highlight: Start Developing Locally, Fast
 
-Use `zksync-cli dev` for an easy way to work with zkSync on your computer. It helps you set up and manage local zkSync and Ethereum nodes, Block Explorer, Wallet, and Bridge without hassle.
+Use `npx zksync-cli dev` for an easy way to work with zkSync on your computer. It helps you set up and manage local zkSync and Ethereum nodes, Block Explorer, Wallet, and Bridge without hassle.
 
 ### Quick ‘dev’ Commands
 
-- `zksync-cli dev start`: Begin your local development environment (first-time users will be prompted to configure)
-- `zksync-cli dev clean`: Clear data for configured modules
-- `zksync-cli dev config`: Choose modules to run in local development environment
+- `npx zksync-cli dev start`: Begin your local development environment (first-time users will be prompted to configure)
+- `npx zksync-cli dev clean`: Clear data for configured modules
+- `npx zksync-cli dev config`: Choose modules to run in local development environment
 
-Run `zksync-cli help dev` for more commands and details.
+Run `npx zksync-cli help dev` for more commands and details.
 
 ### Other Essential Commands
 
 - **Basic Operations**:
-  - `zksync-cli create project {FOLDER_NAME}`: Creates a project in a specified folder.
-  - `zksync-cli bridge deposit`: Moves funds from Ethereum (L1) to zkSync (L2).
-  - `zksync-cli bridge withdraw` and `zksync-cli bridge withdraw-finalize`: Manage funds withdrawal from zkSync (L2) to Ethereum (L1).
+  - `npx zksync-cli create`: Creates a project in a specified folder. [More info](#quick-scaffolding-with-templates).
+  - `npx zksync-cli bridge deposit`: Moves funds from Ethereum (L1) to zkSync (L2).
+  - `npx zksync-cli bridge withdraw` and `npx zksync-cli bridge withdraw-finalize`: Manage funds withdrawal from zkSync (L2) to Ethereum (L1).
 - **Help & Info**:
-  - `zksync-cli help`: General help.
-  - `zksync-cli help {command}`: Detailed command usage info.
-  - `zksync-cli --version`: CLI version info.
+  - `npx zksync-cli help`: General help.
+  - `npx zksync-cli help {command}`: Detailed command usage info.
+  - `npx zksync-cli --version`: CLI version info.
 
 ::: info Deposit and withdraw times
 
@@ -61,16 +57,34 @@ Run `zksync-cli help dev` for more commands and details.
 
 More commands and updates are coming! If you have suggestions, [open an issue on GitHub](https://github.com/matter-labs/zksync-cli/issues/new).
 
-### Project Templates
+To simplify and streamline the templates section, you can consider the following edits:
 
-Create projects with these templates using `zksync-cli create project`:
+---
 
-- [Hardhat + Solidity](https://github.com/matter-labs/zksync-hardhat-template).
-- [Hardhat + Vyper](https://github.com/matter-labs/zksync-hardhat-vyper-template).
+### Quick Scaffolding with Templates
+
+Jumpstart your projects with `npx zksync-cli create` using our updated templates:
+
+#### For Frontend Development
+
+- **Frameworks**: Utilize templates for popular frameworks like Vue, React, Next.js, Nuxt, and Vite.
+- **Libraries & Tools**: Options include viem, Ethers, Web3Modal, RainbowKit.
+- **Resources**: [Frontend Templates on GitHub](https://github.com/matter-labs/zksync-frontend-templates#readme).
+
+#### For Smart Contracts
+
+- **Solidity**: Deploy and test using Hardhat with our [Solidity Template](https://github.com/matter-labs/zksync-hardhat-template#readme).
+- **Vyper**: Explore our [Vyper Template](https://github.com/matter-labs/zksync-hardhat-vyper-template#readme) for Hardhat integration.
+
+#### For Scripting and Automation
+
+- **Node.js Applications**: Automate interactions and advanced zkSync operations.
+- **Features**: Includes examples for wallet and contract interactions using either viem or Ethers.
+- **Resources**: [Scripting Templates on GitHub](https://github.com/matter-labs/zksync-scripting-templates#readme).
 
 ### 🔗 Supported Chains
 
-zkSync CLI supports Era Testnet and Era Mainnet by default. Use other networks by overriding L1 and L2 RPC URLs: `zksync-cli bridge deposit --l2-rpc=http://... --l1-rpc=http://...`
+zkSync CLI supports Era Testnet and Era Mainnet by default. Use other networks by overriding L1 and L2 RPC URLs: `npx zksync-cli bridge deposit --l2-rpc=http://... --l1-rpc=http://...`
 
 For using [local setup (dockerized testing node)](../testing/dockerized-testing.md) with default RPC URLs, select `Local Dockerized node` in CLI or use `--chain local-dockerized`.
 


### PR DESCRIPTION
# What :computer: 
* `zksync-cli create project` command renamed to `zksync-cli create`
* Always use `npx` when showcasing zksync-cli commands

# Why :hand:
* Change command according to the update
* It seems a lot of people still install it globally, this will make them not receive latest updates automatically.

# Notes :memo:
* Related zksync-cli PR - https://github.com/matter-labs/zksync-cli/pull/76