### PR TITLE
[QA] Add zksync-cli instructions for l1-l2 tutorial

### DIFF
--- a/docs/dev/how-to/send-transaction-l1-l2.md
+++ b/docs/dev/how-to/send-transaction-l1-l2.md
@@ -239,10 +239,10 @@ User needs to perform next steps:
 @tab npx
 
 ```npx
-  npx zksync-cli@latest dev config
+  npx zksync-cli dev config
   // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
   // choose: BE and Portal (optional)
-  npx zksync-cli@latest dev start
+  npx zksync-cli dev start
 ```
 
 @tab npm

--- a/docs/dev/how-to/send-transaction-l1-l2.md
+++ b/docs/dev/how-to/send-transaction-l1-l2.md
@@ -233,7 +233,30 @@ Along with zkSync Era's built-in censorship resistance that requires multi-layer
 
 User needs to perform next steps:
 
-1. Run local node dockerized containers. [`Instructions how to run it`](https://github.com/matter-labs/local-setup/tree/main)
+1. Run local node dockerized containers. [`Instructions how to run it`](https://github.com/matter-labs/local-setup/tree/main) or use [`zksync-cli`](https://github.com/matter-labs/zksync-cli):
+   ::: code-tabs
+   @tab npx
+
+```npx
+  npx zksync-cli@latest dev config
+   // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
+   // choose: BE and Portal (optional)
+   npx zksync-cli@latest dev start
+```
+
+@tab npm
+
+```npm
+  // install zksync-cli
+  npm i -g zksync-cli
+  zksync-cli dev config
+  // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
+  // choose: BE and Portal (optional)
+  zksync-cli dev start
+```
+
+:::
+
 2. In the root folder of the imported project (step 1) create `file.js` and insert there code from example below
 3. In the root folder add `.env` file with private key of wallet to use
 

--- a/docs/dev/how-to/send-transaction-l1-l2.md
+++ b/docs/dev/how-to/send-transaction-l1-l2.md
@@ -234,14 +234,15 @@ Along with zkSync Era's built-in censorship resistance that requires multi-layer
 User needs to perform next steps:
 
 1. Run local node dockerized containers. [`Instructions how to run it`](https://github.com/matter-labs/local-setup/tree/main) or use [`zksync-cli`](https://github.com/matter-labs/zksync-cli):
-   ::: code-tabs
-   @tab npx
+
+::: code-tabs
+@tab npx
 
 ```npx
   npx zksync-cli@latest dev config
-   // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
-   // choose: BE and Portal (optional)
-   npx zksync-cli@latest dev start
+  // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
+  // choose: BE and Portal (optional)
+  npx zksync-cli@latest dev start
 ```
 
 @tab npm

--- a/docs/dev/how-to/send-transaction-l1-l2.md
+++ b/docs/dev/how-to/send-transaction-l1-l2.md
@@ -249,7 +249,7 @@ User needs to perform next steps:
 
 ```npm
   // install zksync-cli
-  npm i -g zksync-cli
+  npm i -g zksync-cli@latest
   zksync-cli dev config
   // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
   // choose: BE and Portal (optional)


### PR DESCRIPTION
New line for using zksync-cli is added.
For the L1-L2 tutorial a new information is added. How user can run local-node using zksync-cli tool. 
Added 2 option for remote run (NPX) and also possibility to run thought local installation.
- for NPX
- for NPM (local package install)

# What :computer: 
[Updated tutorial L1-L2 transaction.](https://era.zksync.io/docs/dev/how-to/send-transaction-l1-l2.html)

# Why :hand:
Provide easier way for user to run local-node.
Motivate to use zksync-cli project.
Provide visibility of simple and quick to use from developer side.

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
