### PR TITLE
fix(api): make clearer description of `hash` parameter in `zks_getBytecodeByHash` rpc method

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -372,9 +372,9 @@ Returns bytecode of a transaction given by its hash.
 
 #### Inputs
 
-| Parameter | Type     | Description             |
-| --------- | -------- | ----------------------- |
-| `hash`    | `H256  ` | Hash address as string. |
+| Parameter | Type     | Description              |
+| --------- | -------- | ------------------------ |
+| `hash`    | `H256  ` | Bytecode hash as string. |
 
 #### curl example
 


### PR DESCRIPTION
# What :computer: 
* Update description of `hash` parameter in `zks_getBytecodeByHash` RPC endpoint.

# Why :hand:
* Address is 20 bytes long, hash is 32 bytes. Previous version of description was:  'Hass address as string'  which did not make any sense.

