### PR TITLE
fix: update zksync-cli rpc option

### DIFF
--- a/docs/tools/zksync-cli/README.md
+++ b/docs/tools/zksync-cli/README.md
@@ -84,7 +84,7 @@ Jumpstart your projects with `npx zksync-cli create` using our updated templates
 
 ### 🔗 Supported Chains
 
-zkSync CLI supports Era Testnet and Era Mainnet by default. Use other networks by overriding L1 and L2 RPC URLs: `npx zksync-cli bridge deposit --l2-rpc=http://... --l1-rpc=http://...`
+zkSync CLI supports Era Testnet and Era Mainnet by default. Use other networks by overriding L1 and L2 RPC URLs: `npx zksync-cli bridge deposit --rpc=http://... --l1-rpc=http://...`
 
 For using [local setup (dockerized testing node)](../testing/dockerized-testing.md) with default RPC URLs, select `Local Dockerized node` in CLI or use `--chain local-dockerized`.
 


### PR DESCRIPTION
# What :computer: 
* Change `--l2-rpc` to `--rpc`

# Why :hand:
* zksync-cli was updated to provide easier and more consistent option names

# Evidence :camera:
<img width="856" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/47187316/63c80b1e-bfc6-4177-b962-69bd7f2b3369">
