### PR TITLE
fix: repetition of "instructions"

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -9,7 +9,7 @@ head:
 
 This section of our documentation is dedicated to getting you started, telling you how to do common tasks, and providing tutorials.
 
-Our docs are open source so feel free to suggest new topics, add new content, or provide useful examples. Check out the [how to contribute instructions](../reference/troubleshooting/docs-contribution/docs.md) instructions for more information.
+Our docs are open source so feel free to suggest new topics, add new content, or provide useful examples. Check out the [how to contribute instructions](../reference/troubleshooting/docs-contribution/docs.md) for more information.
 
 ## Getting started
 


### PR DESCRIPTION
# What:
There's a duplication of the word "instructions."
 "Check out the how to contribute **instructions instructions** for more information." 


