### PR TITLE
fix: moved box-shadow to pseudo element

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -4,12 +4,12 @@
     --pwa-popup-bg-color: #ffffff;
     --pwa-popup-border-color: rgba(0,0,0,0.15);
     --pwa-popup-shadow: 0 4px 16px var(--pwa-popup-border-color);
-    
+
     --pwa-popup-btn-text-color: white;
     --pwa-popup-btn-bg-color: #1e69ff;
     --pwa-popup-btn-hover-bg-color: #0759ff;
     }
-    
+
     body {
         overflow-x: hidden !important;
         font-family: "Inter" !important;
@@ -20,64 +20,60 @@
     div[class*=language-] > button.copy-code-button:not(.pure) {
         background: #8687fb !important;
     }
-    
+
     .theme-container {
         position: relative;
         min-height: calc(100vh - 152px);
         padding-bottom: 152px;
     }
-    .page {
-    }
 
-   
-    
     .footer-wrapper {
         position: absolute;
         bottom: 0;
         left: 0;
         right: 0;
     }
-    
+
     .copy-icon {
         background: #1e69ff !important;
     }
-    
+
     .copyright {
         display: none;
     }
-    
+
     p{
         hyphens: none !important;
         text-align: inherit !important;
     }
-    
-    
+
+
     [data-theme="dark"] .sidebar a{
         color: #FFFFFFCC !important;
     }
-    
+
     [data-theme="dark"] #toc .toc-link {
         color: #FFFFFFCC !important;
     }
-    
+
     #toc .toc-link {
         color: #2C3E50 !important;
     }
-    
+
     .sidebar a {
         color: #2C3E50 !important;
     }
-    
+
     [data-theme="dark"] li {
         color: #FFFFFFCC !important;
     }
-    
+
     * {
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
     }
-    
-    
+
+
     .newsletter-input {
         display: inline-block;
         width: 18rem;
@@ -91,7 +87,7 @@
         box-sizing: border-box;
         border: 1px solid #ddd;
     }
-    
+
     .newsletter-button {
         display: inline-block;
         width: 10rem;
@@ -106,7 +102,7 @@
         border: 1px solid #ccc;
         cursor: pointer;
     }
-    
+
     input[type="submit" i] {
         appearance: auto;
         user-select: none;
@@ -114,65 +110,65 @@
         align-items: flex-start;
         text-align: center;
     }
-    
+
     .landing .hero-img {
         max-width: 70%;
         width: 400px;
         margin: 10px auto;
-    
+
         img {
             width: 100%;
             margin-bottom: 20px;
         }
     }
-    
+
     [data-theme="dark"] img[src*="/era-dark.svg"] {
         content: url("/era-light.svg") !important;
     }
-    
+
     [data-theme="dark"] img[src*="/images/code-light.png"] {
         content: url("/images/code-dark.png");
     }
-    
+
     [data-theme="light"] img[src*="/images/code-light.png"] {
         content: url("/images/code-light.png");
     }
-    
+
     #toc {
         padding: 0 9rem !important;
     }
-    
+
     @media screen and (max-width: 1600px) {
         #toc {
             padding: 0 4rem !important;
         }
     }
-    
+
     span.title {
         font-size: 14px !important;
     }
-    
+
     hr{
         display: none !important;
     }
-    
+
     tbody td a {
         white-space: nowrap;
     }
-    
+
     a.title {
         font-weight: 700 !important;
     }
-    
+
     .logo {
         height: 1.5rem !important;
         padding: 0.70rem 0 !important;
     }
-    
+
     .external-link-icon {
         padding-left: 4px;
     }
-    
+
     /* Mobile */
     @media screen and (max-width: 419px) {
         div[class*=language-] > button.copy-code-button:not(.pure) {
@@ -186,98 +182,98 @@
     p.description {
         font-size: 16px !important;
     }
-    
+
     h1#main-title {
         font-size: 30px !important;
     }
-    
+
     .home.project .features {
-    
+
         border-top: none !important;
     }
-    
-    
-    
+
+
+
     //Homepage Redesign
     $light-selector: 'html[data-theme="light"]';
     $dark-selector: 'html[data-theme="dark"]';
-    
+
     $light-text: #fff;
     $dark-text: #2c3e50;
     $dark-background-color: #1d2536;
     $background-color: #fff;
     $border-color: #e5e7eb;
-    
+
     [data-theme="dark"] a.title {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] a.title {
         color: $dark-text !important;
     }
-    
+
     [data-theme="light"] img[src*="/zk-sync-era-line-light.svg"] {
         content: url("/zk-sync-era-line-dark.png");
     }
-    
+
     [data-theme="dark"] img[src*="/zk-sync-era-line-light.svg"] {
         content: url("/zk-sync-era-line-light.svg");
     }
-    
+
     [data-theme="dark"] h3 {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] h3{
         color: $dark-text !important;
     }
-    
+
     [data-theme="dark"] h1 {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] h1 {
         color: $dark-text !important;
     }
-    
+
     [data-theme="dark"] h2 {
         color: $light-text !important;
         border-bottom: none !important;
     }
-    
+
     [data-theme="light"] h2{
         color: $dark-text !important;
         border-bottom: none !important;
     }
-    
+
     [data-theme="dark"] h3 {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] h3{
         color: $dark-text !important;
     }
-    
+
     [data-theme="dark"] .feature {
         border: 1px solid #393939;
         border-radius: 8px;
         background-color: #252934;
     }
-    
+
     [data-theme="light"] .feature {
         border: 1px solid #e5e7eb;
         border-radius: 8px;
         background-color: $background-color;
     }
-    
+
     [data-theme="light"] .font-icon {
         color: #1e69ff !important;
     }
-    
+
     [data-theme="dark"] .font-icon {
         color: #1e69ff !important;
     }
-    
+
     .home.project .feature .font-icon {
         height: 44px;
         width: 44px;
@@ -286,17 +282,17 @@
         justify-content: center;
         align-items: center;
     }
-    
+
     span{
         font-size: 16px;
     }
-    
+
     //Homepage css
-    
+
     [data-theme="dark"] .site-name {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] .site-name {
         color: $dark-text !important;
     }
@@ -304,7 +300,7 @@
     [data-theme="dark"] .google-translate-select-dropdown__menu li.selected {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] .google-translate-select-dropdown__menu li.selected {
         color: $dark-text !important;
     }
@@ -312,7 +308,7 @@
     [data-theme="dark"] .google-translate-select-dropdown__menu {
         background-color: $dark-text !important;
     }
-    
+
     [data-theme="light"] .google-translate-select-dropdown__menu {
         background-color: $light-text !important;
     }
@@ -320,136 +316,156 @@
     [data-theme="dark"] .google-translate-select-dropdown__menu__item :hover {
         color: #1d2536 !important;
     }
-    
+
     [data-theme="light"] .google-translate-select-dropdown__menu__item :hover {
         color: #1d2536 !important;
     }
-    
+
     [data-theme="light"] img[src*="../../assets/images/code-light.png"] {
         content: url("../../assets/images/code-dark.png");
-        
+
     }
-    
+
     [data-theme="dark"] img[src*="../../assets/images/code-light.png"] {
         content: url("../../assets/images/code-dark.png") !important;
     }
-    
+
     @media all and (max-width: 400px) {
         .card-container {
             flex-direction: column;
             min-width: none;
         }
     }
-    
+
     .card-container {
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
         box-sizing: border-box;
         flex-flow: row wrap;
-    
+
         .card {
+            position: relative;
             flex: 1;
             margin: 10px;
             display: flex;
             min-width: 220px;
-            //box-shadow: 0 0 2px 2px rgba(0,0,0,.05);
             background: inherit;
+            text-decoration: none !important;
             -webkit-transition: .3s all ease;
             transition: .3s all ease;
-            border-radius: 8px;
+
+            &,
+            &:after {
+                border-radius: 8px;
+            }
+
+            &:after {
+                content: "";
+                position: absolute;
+                top: 0;
+                left: 0;
+
+                height: 100%;
+                width: 100%;
+
+                box-shadow: 0 0 8px 3px rgba(0,0,0,.15);
+                opacity: 0;
+                will-change: opacity;
+                transition: .3s opacity ease;
+            }
+
             h3 {
                 font-size: 18px;
-                font-weight: 500; 
+                font-weight: 500;
+            }
+
+            &:hover {
+                cursor: pointer;
+                transform: scale(1.025);
+
+                &:after {
+                    opacity: 1;
+                }
             }
         }
     }
-    
-    .card-container .card:hover {
-        box-shadow: 0 0 8px 3px rgba(0,0,0,.15);
-        transform: scale(1.025);
-        opacity: 1;
-        text-decoration: none !important;
-        transition: .3s all ease;
-        opacity: .7;
-        cursor: pointer;
-    }
-    
+
     .card-container .card .content {
         border: 1px solid hsla(0,0%,100%,.07);
         flex-grow: 1;
         gap: 12px;
         padding: 20px;
     }
-    
+
     .cards-heading {
         margin-top: 40px;
         margin-bottom: 20px;
         color: #1e69ff;
     }
-    
+
     .intro-text {
         font-size: 16px !important;
         font-weight: 500 !important;
         margin-bottom: 20px;
     }
-    
+
     .title-section {
         font-size: 22px;
         font-weight: 700;
     }
-    
+
     [data-theme="dark"] .card-container .card .content {
         border: 1px solid #393939;
         border-radius: 8px;
         background-color: #252934;
     }
-    
+
     [data-theme="dark"] .card-container .card .content {
         border: 1px solid #393939;
         border-radius: 8px;
         background-color: #252934;
     }
-    
+
     [data-theme="light"] .card-container .card .content {
         border: 1px solid #e5e7eb;
         border-radius: 8px;
         background-color: $background-color;
     }
-    
+
     [data-theme="dark"]  p {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"]  p {
         color: $dark-text !important;
     }
-    
+
     .navbar .nav-item > .nav-link:hover::after, .navbar .nav-item > .nav-link.active::after {
         bottom: -14px;
     }
-    
+
     .fade-slide-y-enter-active {
         transition: all 0.15s ease;
     }
-    
+
     .fade-slide-y-leave-active {
         transition: all 0.15s cubic-bezier(1, 0.5, 0.8, 1);
     }
-    
+
     div.hero-img {
         pointer-events: none !important;
         cursor: default !important;
     }
-    
+
     .page-meta .contributors {
         text-align: left !important;
     }
-    
+
     .newsletter-button {
         color: #1e69ff;
     }
-    
+
     .container{
         width: 100%;
         display: flex;
@@ -467,8 +483,8 @@
         max-width: 1024px;
         padding-bottom: 30px;
         padding-left: 9%;
-        
-    
+
+
     }
     #footer{
         //background-color: #24262b;
@@ -485,17 +501,17 @@
         text-decoration: underline;
     }
     .footer-social{
-        padding-top: 1rem;  
+        padding-top: 1rem;
     }
 
     .footer-social a, .footer-links a{
         padding: 1rem 1rem 0 1rem;
     }
-    
+
     [data-theme="dark"] #footer {
         background-color: #24262b !important;
     }
-    
+
     [data-theme="light"] #footer {
         background-color: #f5f6f7 !important;
     }
@@ -506,23 +522,23 @@
     .footer-col ul{
         list-style: none !important;
     }
-    
+
     [data-theme="dark"] .footer-col h4 {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] .footer-col h4 {
         color: $dark-text !important;
     }
-    
+
     .footer-col ul li:not(:last-child){
         margin-bottom: 10px;
     }
-    
+
     [data-theme="dark"] .footer-col ul li a {
         color: $light-text !important;
     }
-    
+
     [data-theme="light"] .footer-col ul li a {
         color: $dark-text !important;
     }
@@ -548,13 +564,13 @@
         color: #24262b;
         background-color: #ffffff;
     }
-    
+
     /*responsive*/
     @media(max-width: 767px){
         .footer-col{
             width: 50%;
             margin-bottom: 30px;
-            
+
         }
         .row {
             flex-direction: column;
@@ -572,24 +588,23 @@
             width: 100%;
         }
     }
-    
+
     .toggle-sidebar-wrapper .arrow  {
         background-color: #edeff3;
         border-radius: 50%;
         font-size: 32px;
     }
-    
+
     [data-theme="dark"] .toggle-sidebar-wrapper .arrow  {
         background-color: #24262b !important;
     }
-    
+
     [data-theme="light"] .toggle-sidebar-wrapper .arrow {
         background-color: #f5f6f7 !important;
     }
-    
+
     .theme-hope-content:not(.custom) > h3, .theme-hope-content:not(.custom) > h4 {
         margin-top: calc(-4.0rem);
-        
     }
 
     .google-translate-select-flag {


### PR DESCRIPTION
# What :computer: 
* Changed the hover on `.card` from transitioning the box-shadow property to transitioning the opacity
* There were 2 opacity values on `.card` on the hover state (1 and 0.7) that were overriding each other, so I removed the 0.7 value

# Why :hand:
* Box-shadow should not be transitioned https://tobiasahlin.com/blog/how-to-animate-box-shadow/

# Evidence :camera:
<img width="1512" alt="Screenshot 2023-12-10 at 10 51 04 PM" src="https://github.com/matter-labs/zksync-web-era-docs/assets/10190995/45641337-cbea-46af-810c-4e9ca8cbe81c">

# Notes :memo:
* VSCode automatically removes extra whitespace, so it looks like more changes than what it really is
