### PR TITLE
chore(plugins): migration from zksync2-js to zksync-ethers

### DIFF
--- a/docs/.vuepress/sidebar/en.ts
+++ b/docs/.vuepress/sidebar/en.ts
@@ -236,7 +236,7 @@ export const enSidebar = sidebar({
             "/tools/hardhat/hardhat-zksync-verify",
             "/tools/hardhat/hardhat-zksync-verify-vyper",
             "/tools/hardhat/hardhat-zksync-node",
-            "/tools/hardhat/hardhat-zksync-zksync2js",
+            "/tools/hardhat/hardhat-zksync-ethers",
             "/tools/hardhat/other-plugins",
           ],
         },

--- a/docs/tools/hardhat/getting-started.md
+++ b/docs/tools/hardhat/getting-started.md
@@ -18,7 +18,7 @@ zkSync Era has the following official plugins for Hardhat:
 - [@matterlabs/hardhat-zksync-verify](./hardhat-zksync-verify.md) - used to verify smart contracts.
 - [@matterlabs/hardhat-zksync-verify-vyper](./hardhat-zksync-verify-vyper.md) - used to verify vyper smart contracts.
 - [@matterlabs/hardhat-zksync-upgradable](./hardhat-zksync-upgradable.md) - used to deploy, update, and verify proxy smart contracts.
-- [@matterlabs/hardhat-zksync-zksync2js](./hardhat-zksync-zksync2js.md) - wrapper around zksync2-js with some extra Hardhat-specific functionality.
+- [@matterlabs/hardhat-zksync-ethers](./hardhat-zksync-ethers.md) - wrapper around zksync-ethers with some extra Hardhat-specific functionality.
 
 ::: tip Additional plugins
 Learn more about [other plugins from the community](./other-plugins.md) that you can use with zkSync Era.
@@ -156,7 +156,7 @@ The `artifacts-zk` and `cache-zk` folders are included in the `.gitignore` file.
 The `deploy-greeter.ts` script is in the `deploy` folder. This script uses the `Deployer` class from the `hardhat-zksync-deploy` package to deploy the `Greeter.sol` contract.
 
 ```typescript
-import { Wallet, utils } from "zksync-web3";
+import { Wallet, utils } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
@@ -196,7 +196,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 
   // Deploy this contract. The returned object will be of a `Contract` type, similarly to ones in `ethers`.
   // `greeting` is an argument for contract constructor.
-  const parsedFee = ethers.utils.formatEther(deploymentFee.toString());
+  const parsedFee = ethers.formatEther(deploymentFee);
   console.log(`The deployment is estimated to cost ${parsedFee} ETH`);
 
   const greeterContract = await deployer.deploy(artifact, [greeting]);
@@ -205,7 +205,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
   console.log("constructor args:" + greeterContract.interface.encodeDeploy([greeting]));
 
   // Show the contract info.
-  const contractAddress = greeterContract.address;
+  const contractAddress = await greeterContract.getAddress();
   console.log(`${artifact.contractName} was deployed to ${contractAddress}`);
 }
 ```
@@ -245,7 +245,7 @@ The template project contains another script to interact with the contract.
 1. Enter the address of the deployed Greeter contract in the `CONTRACT_ADDRESS` variable of the `use-greeter.ts` script:
 
 ```typescript
-import { Provider } from "zksync-web3";
+import { Provider } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -318,4 +318,4 @@ The message now is Hello people!
 ## Learn more
 
 - To learn more about the zkSync Hardhat plugins check out the [plugins documentation](./plugins.md).
-- If you want to know more about how to interact with zkSync using Javascript, check out the [zksync-web3 Javascript SDK documentation](../../api/js) .
+- If you want to know more about how to interact with zkSync using Javascript, check out the [zksync-ethers Javascript SDK documentation](../../api/js) .

--- a/docs/tools/hardhat/hardhat-zksync-chai-matchers.md
+++ b/docs/tools/hardhat/hardhat-zksync-chai-matchers.md
@@ -15,7 +15,7 @@ Currently, it is used in combination with [local testing environment](../testing
 ::: info
 
 - Since responses from transactions that revert are highly dependent on the RPC implementation, all [Hardhat](https://hardhat.org/hardhat-chai-matchers/docs/overview) chai matchers that start with `revert` have been affected (without any changes to the chai matchers interface).
-- In addition, the `options` argument from `changeEtherBalance`/`changeEtherBalances` now includes the `overrides` field in order to support `zksync-web3` transfer methods with overrides.
+- In addition, the `options` argument from `changeEtherBalance`/`changeEtherBalances` now includes the `overrides` field in order to support `zksync-ethers` transfer methods with overrides.
   :::
 
 ## Installation
@@ -58,7 +58,7 @@ await expect(() =>
     to: receiver.address,
     amount: 2000,
   })
-).to.changeEtherBalance(sender.address, BigInt("-2000"));
+).to.changeEtherBalance(sender.address, -2000);
 
 await expect(() =>
   sender.sendTransaction({

--- a/docs/tools/hardhat/hardhat-zksync-deploy.md
+++ b/docs/tools/hardhat/hardhat-zksync-deploy.md
@@ -29,7 +29,7 @@ Add the latest version of this plugin to your project with the following command
 @tab:active yarn
 
 ```bash
-yarn add -D @matterlabs/hardhat-zksync-deploy
+yarn add -D @matterlabs/hardhat-zksync-deploy ethers zksync-ethers
 ```
 
 @tab npm
@@ -44,7 +44,7 @@ npm i -D @matterlabs/hardhat-zksync-deploy
 
 #### `Deployer`
 
-The main export of this plugin is the `Deployer` class. It is used to wrap a `zksync-web3` Wallet instance and provides a convenient interface to deploy smart contracts and account abstractions. It's main methods are:
+The main export of this plugin is the `Deployer` class. It is used to wrap a `zksync-ethers` Wallet instance and provides a convenient interface to deploy smart contracts and account abstractions. It's main methods are:
 
 ```typescript
 class Deployer {

--- a/docs/tools/hardhat/hardhat-zksync-ethers.md
+++ b/docs/tools/hardhat/hardhat-zksync-ethers.md
@@ -1,12 +1,15 @@
-# `hardhat-zksync-zksync2js`
+# `hardhat-zksync-ethers`
 
-This plugin brings to Hardhat the zksync2-js library, which allows you to interact with the zksync network in a simple way.
-
-Learn more about the latest updates in the [changelog](https://github.com/matter-labs/hardhat-zksync/blob/main/packages/hardhat-zksync-zksync2js/CHANGELOG.md)
+:::warning SDK Deprecation Notice
+The `zksync2-js` SDK is now deprecated. \
+In line with this, the `hardhat-zksync-zksync2js` package will also be deprecated. \
+Moving forward, this package will be renamed to `hardhat-zksync-ethers` and will utilize the newly introduced `zksync-ethers` SDK. \
+Please update your dependencies accordingly to ensure compatibility and continued support.
+:::
 
 ## Installation
 
-[@matterlabs/hardhat-zksync-zksync2js](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-zksync2js)
+[@matterlabs/hardhat-zksync-ethers](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-ethers)
 
 Add the latest version of this plugin to your project with the following command:
 
@@ -15,13 +18,13 @@ Add the latest version of this plugin to your project with the following command
 @tab:active yarn
 
 ```bash
-yarn add -D @matterlabs/hardhat-zksync-zksync2js zksync2-js ethers
+yarn add -D @matterlabs/hardhat-zksync-ethers zksync-ethers ethers
 ```
 
 @tab npm
 
 ```bash
-npm i -D @matterlabs/hardhat-zksync-zksync2js
+npm i -D @matterlabs/hardhat-zksync-ethers
 ```
 
 :::
@@ -31,7 +34,7 @@ npm i -D @matterlabs/hardhat-zksync-zksync2js
 Import the package in the `hardhat.config.ts` file:
 
 ```ts
-import "@matterlabs/hardhat-zksync-zksync2js";
+import "@matterlabs/hardhat-zksync-ethers";
 ```
 
 ## Tasks
@@ -40,12 +43,12 @@ This plugin creates no additional tasks.
 
 ## Environment extensions
 
-This plugins adds an zksync2-js object to the Hardhat Runtime Environment.
-This object has the same API as [zksync2-js](../../api/js/zksync2-js/getting-started.md), with some extra Hardhat-specific functionality.
+This plugins adds an zksync-ethers object to the Hardhat Runtime Environment.
+This object has the same API as [zksync-ethers](../../api/js/zksync2-js/getting-started.md), with some extra Hardhat-specific functionality.
 
 ## Helpers
 
-Helpers added to zksync2-js object:
+Helpers added to zksync-ethers object:
 
 ```ts
 interface FactoryDeps {
@@ -100,13 +103,13 @@ function deployContract: (artifact: ZkSyncArtifact, constructorArguments: any[],
 
 ## Usage
 
-Install it and access zksync2-js through the Hardhat Runtime Environment anywhere you need it (tasks, scripts, tests, etc). For example:
+Install it and access zksync-ethers through the Hardhat Runtime Environment anywhere you need it (tasks, scripts, tests, etc). For example:
 
 Task usage:
 
 ```ts
 task("getFeeData", "Returns a fee data.").setAction(async (hre) => {
-  return await hre.zksync2js.provider.getFeeData();
+  return await hre.zksyncEthers.provider.getFeeData();
 });
 ```
 
@@ -117,11 +120,11 @@ export default async function (hre: HardhatRuntimeEnvironment) {
   console.info(chalk.yellow(`Running deploy`));
 
   //automatically connected to the selected network
-  const gasPrice = await hre.zksync2js.provider.send("eth_gasPrice", []);
+  const gasPrice = await hre.zksyncEthers.provider.send("eth_gasPrice", []);
   assert.strictEqual("0xee6b280", gasPrice);
 
   //getContractFactory with default wallet
-  const greeterFactory = await hre.zksync2js.getContractFactory("Greeter");
+  const greeterFactory = await hre.zksyncEthers.getContractFactory("Greeter");
   const greeter = (await greeterFactory.deploy("Hello, world!")) as zk.Contract;
 
   console.info(chalk.green(`Greeter deployed to: ${await greeter.getAddress()}`));
@@ -132,7 +135,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
   await tx.wait();
   console.info(chalk.green(`Greeter greeting set to: ${await greeter.greet()}`));
 
-  const wallet = await hre.zksync2js.getWallet("0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110");
+  const wallet = await hre.zksyncEthers.getWallet("0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110");
   console.info(chalk.green(`Wallet address: ${await wallet.getAddress()}`));
 }
 ```

--- a/docs/tools/hardhat/hardhat-zksync-upgradable.md
+++ b/docs/tools/hardhat/hardhat-zksync-upgradable.md
@@ -590,7 +590,7 @@ async function main() {
   await hre.zkUpgrades.upgradeBeacon(deployer.zkWallet, await beacon.getAddress(), boxV2Implementation);
   console.log("Successfully upgraded beacon Box to BoxV2 on address: ", await beacon.getAddress());
 
-  const attachTo = new zk.ContractFactoryy<any[], Contract>(boxV2Implementation.abi, boxV2Implementation.bytecode, deployer.zkWallet, deployer.deploymentType);
+  const attachTo = new zk.ContractFactory<any[], Contract>(boxV2Implementation.abi, boxV2Implementation.bytecode, deployer.zkWallet, deployer.deploymentType);
   const upgradedBox = await attachTo.attach(await boxBeaconProxy.getAddress());
 
   upgradedBox.connect(zkWallet);

--- a/docs/tools/hardhat/hardhat-zksync-upgradable.md
+++ b/docs/tools/hardhat/hardhat-zksync-upgradable.md
@@ -359,7 +359,7 @@ async function main() {
 
   const box = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, await beacon.getAddress(), boxContract, [42]);
   await box.waitForDeployment();
-  console.log(contractName + " beacon proxy deployed to: ", await beacon.getAdress());
+  console.log(contractName + " beacon proxy deployed to: ", await beacon.getAddress());
 
   box.connect(zkWallet);
   const value = await box.retrieve();

--- a/docs/tools/hardhat/hardhat-zksync-upgradable.md
+++ b/docs/tools/hardhat/hardhat-zksync-upgradable.md
@@ -143,7 +143,7 @@ The `deployProxy` method deploys your implementation contract on zkSync Era, dep
 
 ```typescript
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
-import { Wallet } from "zksync-web3";
+import { Wallet } from "zksync-ethers";
 
 import * as hre from "hardhat";
 
@@ -153,19 +153,19 @@ async function main() {
 
   // mnemonic for local node rich wallet
   const testMnemonic = "stuff slice staff easily soup parent arm payment cotton trade scatter struggle";
-  const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+  const zkWallet = Wallet.fromMnemonic(testMnemonic);
 
   const deployer = new Deployer(hre, zkWallet);
 
   const contract = await deployer.loadArtifact(contractName);
   const box = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [42], { initializer: "initialize" });
 
-  await box.deployed();
-  console.log(contractName + " deployed to:", box.address);
+  await box.waitForDeployment();
+  console.log(contractName + " deployed to:", await box.getAddress());
 
   box.connect(zkWallet);
   const value = await box.retrieve();
-  console.log("Box value is: ", value.toNumber());
+  console.log("Box value is: ", value);
 }
 
 main().catch((error) => {
@@ -221,12 +221,12 @@ Since the provider was instantiated on creating the `Deployer` class, based on y
 On the other hand, if you need to explicitly set the provider, do that with the code below:
 
 ```typescript
-  import { Provider } from "zksync-web3";
+  import { Provider } from "zksync-ethers";
 
   const provider = new Provider("https://sepolia.era.zksync.dev");
 
   const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
-  const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+  const zkWallet = Wallet.fromMnemonic(testMnemonic);
   zkWallet.connect(provider);
 
   const deployer = new Deployer(hre, zkWallet);
@@ -294,7 +294,7 @@ async function main() {
 
     // mnemonic for local node rich wallet
     const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
-    const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+    const zkWallet = Wallet.fromMnemonic(testMnemonic);
     ...
 ```
 
@@ -313,7 +313,7 @@ This allows for more advanced upgrade patterns, such as adding or removing funct
 ```typescript
 // mnemonic for local node rich wallet
 const testMnemonic = "stuff slice staff easily soup parent arm payment cotton trade scatter struggle";
-const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+const zkWallet = Wallet.fromMnemonic(testMnemonic);
 
 const deployer = new Deployer(hre, zkWallet);
 
@@ -339,7 +339,7 @@ After that, your beacon proxy contract is deployed on the network, and you can i
 
 ```typescript
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
-import { Wallet } from "zksync-web3";
+import { Wallet } from "zksync-ethers";
 
 import * as hre from "hardhat";
 
@@ -348,22 +348,22 @@ async function main() {
   console.log("Deploying " + contractName + "...");
   // mnemonic for local node rich wallet
   const testMnemonic = "stuff slice staff easily soup parent arm payment cotton trade scatter struggle";
-  const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+  const zkWallet = Wallet.fromMnemonic(testMnemonic);
 
   const deployer = new Deployer(hre, zkWallet);
 
   const boxContract = await deployer.loadArtifact(contractName);
   const beacon = await hre.zkUpgrades.deployBeacon(deployer.zkWallet, boxContract);
-  await beacon.deployed();
-  console.log("Beacon deployed to:", beacon.address);
+  await beacon.waitForDeployment();
+  console.log("Beacon deployed to:", await beacon.getAdress());
 
-  const box = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, beacon, boxContract, [42]);
-  await box.deployed();
-  console.log(contractName + " beacon proxy deployed to: ", box.address);
+  const box = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, await beacon.getAddress(), boxContract, [42]);
+  await box.waitForDeployment();
+  console.log(contractName + " beacon proxy deployed to: ", await beacon.getAdress());
 
   box.connect(zkWallet);
   const value = await box.retrieve();
-  console.log("Box value is: ", value.toNumber());
+  console.log("Box value is: ", value);
 }
 
 main().catch((error) => {
@@ -564,33 +564,34 @@ The example below deploys and upgrades a smart contract using a beacon proxy:
 
 ```typescript
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
-import { Wallet } from "zksync-web3";
-import * as zk from "zksync-web3";
+import { Wallet } from "zksync-ethers";
+import * as zk from "zksync-ethers";
+import { Contract } from "ethers";
 
 import * as hre from "hardhat";
 
 async function main() {
   // mnemonic for local node rich wallet
   const testMnemonic = "stuff slice staff easily soup parent arm payment cotton trade scatter struggle";
-  const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+  const zkWallet = Wallet.fromMnemonic(testMnemonic);
   const deployer = new Deployer(hre, zkWallet);
 
   // deploy beacon proxy
   const contractName = "Box";
   const contract = await deployer.loadArtifact(contractName);
   const beacon = await hre.zkUpgrades.deployBeacon(deployer.zkWallet, contract);
-  await beacon.deployed();
+  await beacon.waitForDeployment();
 
-  const boxBeaconProxy = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, beacon, contract, [42]);
-  await boxBeaconProxy.deployed();
+  const boxBeaconProxy = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, await beacon.getAddress(), contract, [42]);
+  await boxBeaconProxy.waitForDeployment();
 
   // upgrade beacon
   const boxV2Implementation = await deployer.loadArtifact("BoxV2");
-  await hre.zkUpgrades.upgradeBeacon(deployer.zkWallet, beacon.address, boxV2Implementation);
-  console.log("Successfully upgraded beacon Box to BoxV2 on address: ", beacon.address);
+  await hre.zkUpgrades.upgradeBeacon(deployer.zkWallet, await beacon.getAddress(), boxV2Implementation);
+  console.log("Successfully upgraded beacon Box to BoxV2 on address: ", await beacon.getAddress());
 
-  const attachTo = new zk.ContractFactory(boxV2Implementation.abi, boxV2Implementation.bytecode, deployer.zkWallet, deployer.deploymentType);
-  const upgradedBox = await attachTo.attach(boxBeaconProxy.address);
+  const attachTo = new zk.ContractFactoryy<any[], Contract>(boxV2Implementation.abi, boxV2Implementation.bytecode, deployer.zkWallet, deployer.deploymentType);
+  const upgradedBox = await attachTo.attach(await boxBeaconProxy.getAddress());
 
   upgradedBox.connect(zkWallet);
   // wait some time before the next call
@@ -669,7 +670,7 @@ In the examples provided below, we will use the a Box contract and the deployer 
 ```typescript
 // mnemonic for local node rich wallet
 const testMnemonic = "stuff slice staff easily soup parent arm payment cotton trade scatter struggle";
-const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+const zkWallet = Wallet.fromMnemonic(testMnemonic);
 
 const deployer = new Deployer(hre, zkWallet);
 

--- a/docs/tools/hardhat/hardhat-zksync-upgradable.md
+++ b/docs/tools/hardhat/hardhat-zksync-upgradable.md
@@ -355,7 +355,7 @@ async function main() {
   const boxContract = await deployer.loadArtifact(contractName);
   const beacon = await hre.zkUpgrades.deployBeacon(deployer.zkWallet, boxContract);
   await beacon.waitForDeployment();
-  console.log("Beacon deployed to:", await beacon.getAdress());
+  console.log("Beacon deployed to:", await beacon.getAddress());
 
   const box = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, await beacon.getAddress(), boxContract, [42]);
   await box.waitForDeployment();

--- a/docs/tools/hardhat/migrating-to-zksync.md
+++ b/docs/tools/hardhat/migrating-to-zksync.md
@@ -185,7 +185,7 @@ To deploy your contracts you need to use the `Deployer` class from the `hardhat-
 Here is a basic deployment script for a `Greeter` contract:
 
 ```typescript
-import { utils, Wallet } from "zksync-web3";
+import { utils, Wallet } from "zksync-ethers";
 import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
@@ -209,7 +209,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
   const greeterContract = await deployer.deploy(artifact, [greeting]);
 
   // Show the contract info.
-  console.log(`${artifact.contractName} was deployed to ${greeterContract.address}`);
+  console.log(`${artifact.contractName} was deployed to ${await greeterContract.getAddress()}`);
 }
 ```
 
@@ -241,16 +241,16 @@ Check out a detailed [approach](./hardhat-zksync-deploy.md) on how to use `hardh
 
 ## Frontend integration
 
-You can interact with your contracts using the `zksync-web3` Javascript library. This SDK has been built on top of ethers and uses the same classes (`Provider`, `Contract`, `Wallet`) so in a lot of cases, you just need to import these classes from `zksync-web3` instead of `ethers`:
+You can interact with your contracts using the `zksync-ethers` Javascript library. This SDK has been built on top of ethers and uses the same classes (`Provider`, `Contract`, `Wallet`) so in a lot of cases, you just need to import these classes from `zksync-ethers` instead of `ethers`:
 
 ```typescript
 //import { utils, Provider, Contract, Wallet } from "ethers";
-import { utils, Provider, Contract, Wallet } from "zksync-web3";
+import { utils, Provider, Contract, Wallet } from "zksync-ethers";
 ```
 
 You also need to use the `contract ABI` from the `artifacts-zk` folder to instantiate contracts.
 
-Apart from the same classes and methods provided by ethers, zksync-web3 includes additional methods for zksync-specific features. You can read more in the [`zksync-web3` documentation](../../api/js/getting-started.md).
+Apart from the same classes and methods provided by ethers, zksync-ethers includes additional methods for zksync-specific features. You can read more in the [`zksync-ethers` documentation](../../api/js/getting-started.md).
 
 ## Verify contracts
 

--- a/docs/tools/hardhat/plugins.md
+++ b/docs/tools/hardhat/plugins.md
@@ -20,7 +20,7 @@ List of official plugins:
 - [hardhat-zksync-verify](./hardhat-zksync-verify.md)
 - [hardhat-zksync-verify-vyper](./hardhat-zksync-verify-vyper.md)
 - [hardhat-zksync-upgradable](./hardhat-zksync-upgradable.md)
-- [/hardhat-zksync-zksync2js](./hardhat-zksync-zksync2js.md)
+- [hardhat-zksync-ethers](./hardhat-zksync-ethers.md)
 
 ::: tip Popular Hardhat plugins
 
@@ -37,7 +37,7 @@ Add the latest version of this plugin to your project with the following command
 @tab:active yarn
 
 ```bash
-yarn add -D @matterlabs/hardhat-zksync-toolbox @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-vyper @matterlabs/hardhat-zksync-chai-matchers @matterlabs/hardhat-zksync-deploy @matterlabs/hardhat-zksync-verify hardhat ethers zksync-web3 @nomicfoundation/hardhat-chai-matchers @nomiclabs/hardhat-ethers @nomicfoundation/hardhat-verify
+yarn add -D @matterlabs/hardhat-zksync-toolbox @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-vyper @matterlabs/hardhat-zksync-chai-matchers @matterlabs/hardhat-zksync-deploy @matterlabs/hardhat-zksync-verify hardhat ethers zksync-ethers @nomicfoundation/hardhat-chai-matchers @nomiclabs/hardhat-ethers @nomicfoundation/hardhat-verify
 ```
 
 @tab npm

--- a/docs/tools/testing/dockerized-testing.md
+++ b/docs/tools/testing/dockerized-testing.md
@@ -164,7 +164,7 @@ module.exports = {
 
 ```ts
 import { expect } from "chai";
-import { Wallet, Provider, Contract } from "zksync-web3";
+import { Wallet, Provider, Contract } from "zksync-ethers";
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 

--- a/docs/tools/testing/era-test-node.md
+++ b/docs/tools/testing/era-test-node.md
@@ -379,7 +379,7 @@ module.exports = {
 
 ```ts
 import { expect } from "chai";
-import { Wallet, Provider, Contract } from "zksync-web3";
+import { Wallet, Provider, Contract } from "zksync-ethers";
 import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 


### PR DESCRIPTION
# What :computer: 
* Migration from zksync2-js to zksync-ethers
* hardhat-zksync-zksyn2js plugin change name to hardhat-zksync-ethers
* Examples update to support ethers v6

