### PR TITLE
docs: update api3-usd-paymaster-tutorial.md

### DIFF
--- a/docs/.vuepress/sidebar/en.ts
+++ b/docs/.vuepress/sidebar/en.ts
@@ -38,7 +38,6 @@ export const enSidebar = sidebar({
           "/dev/tutorials/custom-aa-tutorial.md",
           "/dev/tutorials/aa-daily-spend-limit.md",
           "/dev/tutorials/custom-paymaster-tutorial.md",
-          "/dev/tutorials/api3-usd-paymaster-tutorial.md",
           "/dev/tutorials/gated-nft-paymaster-tutorial.md",
         ]},
       ],

--- a/docs/assets/data/devtools.json
+++ b/docs/assets/data/devtools.json
@@ -261,12 +261,6 @@
       "category": "Oracles",
       "tools": [
         {
-          "name": "API3",
-          "category": "Oracle",
-          "logo": "api3-logo.webp",
-          "url": "https://api3.org/"
-        },
-        {
           "name": "DIA",
           "category": "Oracle",
           "logo": "dia-logo.png",

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -32,5 +32,4 @@ Our docs are open source so feel free to suggest new topics, add new content, or
 - [Account abstraction multisig](./tutorials/custom-aa-tutorial.md): create a native multisig smart contract account.
 - [Daily spending limit account](./tutorials/aa-daily-spend-limit.md): create a smart contract account with a daily spending limit.
 - [Building a custom paymaster](./tutorials/custom-paymaster-tutorial.md): build a paymaster that allows users to pay gas fees with an ERC20 token.
-- [USDC paymaster tutorial with API3](./tutorials/api3-usd-paymaster-tutorial.md): build a paymaster that allows users to pay gas fees with USDC using API3 dAPIs.
 - [Gated NFT paymaster](./tutorials/gated-nft-paymaster-tutorial.md): build a paymaster that allows users to pay 0 gas fees when owning a particular NFT.

--- a/docs/dev/tutorials/README.md
+++ b/docs/dev/tutorials/README.md
@@ -13,7 +13,6 @@ Here is the list of tutorials created and maintained by the zkSync DevRel team t
 - [Account abstraction multisig](./custom-aa-tutorial.md): create a native multisig smart contract account.
 - [Daily spending limit account](./aa-daily-spend-limit.md): create a smart contract account with a daily spending limit.
 - [Building a custom paymaster](./custom-paymaster-tutorial.md): build a paymaster that allows users to pay gas fees with an ERC20 token.
-- [USDC paymaster tutorial with API3](./api3-usd-paymaster-tutorial.md): build a paymaster that allows users to pay gas fees with USDC using API3 dAPIs.
 - [Gated NFT paymaster](gated-nft-paymaster-tutorial.md): build a paymaster that allows users to pay 0 gas fees when owning a particular NFT.
 
 These tutorials were created with the goal of showcasing key features of zkSync Era.

--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -7,7 +7,7 @@ head:
 
 # USDC paymaster tutorial with API3 dAPIs
 
-:::Warning
+::: warning
 This tutorial is currently operational exclusively on the Goerli testnet. Stay tuned for upcoming support for the Sepolia network.
 :::
 
@@ -576,7 +576,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 To configure your private key, copy the `.env.example` file, rename the copy to `.env`, and add your wallet private key.
 
 ```text
-WALLET_PRIVATE_KEY=abcdef12345....
+PRIVATE_KEY=abcdef12345....
 ```
 
 ### 3. Compile and deploy
@@ -585,7 +585,7 @@ From the project root, run the following:
 
 ```sh
 yarn hardhat compile
-yarn hardhat deploy-zksync --script deploy-paymaster.ts
+yarn hardhat deploy-zksync --script deploy-paymaster.ts --network zkSyncTestnetGoerli
 ```
 
 The output should be like this (your values will be different):
@@ -750,7 +750,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 ### 2. Run the script
 
 ```sh
-yarn hardhat deploy-zksync --script use-paymaster.ts
+yarn hardhat deploy-zksync --script use-paymaster.ts --network zkSyncTestnetGoerli
 ```
 
 The output should look something like this:

--- a/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
+++ b/docs/dev/tutorials/api3-usd-paymaster-tutorial.md
@@ -45,12 +45,12 @@ API3 data feeds are known as [dAPIs➚](https://docs.api3.org/guides/dapis/subsc
 
 Within a paymaster, price oracles provide price data on-chain for execution.
 
-For this paymaster tutorial, we use dAPIs to get the price of [ETH/USD](https://market.api3.org/dapis/zksync-goerli-testnet/ETH-USD) and [USDC/USD](https://market.api3.org/dapis/zksync-goerli-testnet/USDC-USD) datafeeds, and then calculate gas in USDC value so that users can pay for their transactions with USDC.
+For this paymaster tutorial, we use dAPIs to get the price of ETH/USD and USDC/USD datafeeds, and then calculate gas in USDC value so that users can pay for their transactions with USDC.
 
 ::: info
 
 - If you want to use an ERC20 token other than USDC, change the dAPIs used in the paymaster.
-- For example, if you want to use DAI, use the [DAI/USD](https://market.api3.org/dapis/zksync-goerli-testnet/DAI-USD) dAPI instead of USDC/USD.
+- For example, if you want to use DAI, use the DAI/USD dAPI instead of USDC/USD.
   :::
 
 ## Complete project
@@ -80,7 +80,7 @@ cd paymaster-dapi
 4. Add the project dependencies:
 
 ```sh
-yarn add -D @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable @api3/contracts
+yarn add -D @api3/contracts
 ```
 
 ## Design


### PR DESCRIPTION
# What :computer: 
* Hide the API3 paymaster tutorial
* Remove API3 from Oracles in Dev Tools

# Why :hand:
* API3 has removed support for our network and the tutorial no longer works
