### PR TITLE
docs: updated era-contracts links

### DIFF
--- a/docs/api/go/paymaster-utils.md
+++ b/docs/api/go/paymaster-utils.md
@@ -14,7 +14,7 @@ The [paymaster utilities library](https://github.com/zksync-sdk/zksync2-go/blob/
 ### `IPaymasterFlow`
 
 Constant ABI definition for
-the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/36fe0fd11aeb2cfe88139e7e09d59a25366668d6/zksync/contracts/interfaces/IPaymasterFlow.sol).
+the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l2-contracts/contracts/interfaces/IPaymasterFlow.sol).
 
 ```go
 IPaymasterFlow := abi.JSON(strings.NewReader(paymasterflow.IPaymasterFlowMetaData.ABI));

--- a/docs/api/js/paymaster-utils.md
+++ b/docs/api/js/paymaster-utils.md
@@ -18,7 +18,7 @@ The [paymaster utilities library](https://github.com/zksync-sdk/zksync-ethers/bl
 - This method is deprecated in favor of [utils.PAYMASTER_FLOW_ABI](./utils.md#paymasterflow).
   :::
 
-Constant ABI definition for the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/36fe0fd11aeb2cfe88139e7e09d59a25366668d6/zksync/contracts/interfaces/IPaymasterFlow.sol).
+Constant ABI definition for the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l2-contracts/contracts/interfaces/IPaymasterFlow.sol).
 
 ```typescript
 export const IPaymasterFlow = new ethers.utils.Interface(require("../../abi/IPaymasterFlow.json").abi);

--- a/docs/api/js/zksync2-js/paymaster-utils.md
+++ b/docs/api/js/zksync2-js/paymaster-utils.md
@@ -19,7 +19,7 @@ The [paymaster utilities library](https://github.com/zksync-sdk/zksync-ethers/bl
   :::
 
 Constant ABI definition for
-the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/36fe0fd11aeb2cfe88139e7e09d59a25366668d6/zksync/contracts/interfaces/IPaymasterFlow.sol).
+the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l2-contracts/contracts/interfaces/IPaymasterFlow.sol).
 
 ```typescript
 export const IPaymasterFlow = new ethers.utils.Interface(require("../abi/IPaymasterFlow.json").abi);

--- a/docs/api/python/paymaster-utils.md
+++ b/docs/api/python/paymaster-utils.md
@@ -14,7 +14,7 @@ The [paymaster utilities library](https://github.com/zksync-sdk/zksync2-go/blob/
 ### `PaymasterFlowEncoder`
 
 Constant ABI definition for
-the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/36fe0fd11aeb2cfe88139e7e09d59a25366668d6/zksync/contracts/interfaces/IPaymasterFlow.sol).
+the [Paymaster Flow Interface](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l2-contracts/contracts/interfaces/IPaymasterFlow.sol).
 
 ```python
 encoder = PaymasterFlowEncoder(zk_web3)

--- a/docs/dev/how-to/estimate-gas.md
+++ b/docs/dev/how-to/estimate-gas.md
@@ -38,7 +38,7 @@ To estimate gas for an L1 to L2 transaction, first gather the required values:
 
 2. Call the [`zks_estimateGasL1ToL2`](../../api/api.md#zks-estimategasl1tol2) method, passing the transaction data. This returns the estimated amount of L2 gas the transaction requires; commonly called **gas limit** or similar in our code and docs.
 
-   - Apply an alias to the addresses in the request if the sender address is a contract. If the sender is an EOA, no aliasing is required. This is implemented by the [`applyL1ToL2Alias`](https://github.com/matter-labs/era-contracts/blob/41c25aa16d182f757c3fed1463c78a81896f65e6/ethereum/contracts/vendor/AddressAliasHelper.sol#L28) Solidity function.
+   - Apply an alias to the addresses in the request if the sender address is a contract. If the sender is an EOA, no aliasing is required. This is implemented by the [`applyL1ToL2Alias`](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l1-contracts/contracts/vendor/AddressAliasHelper.sol#L28) Solidity function.
 
 3. Call the [`l2TransactionBaseCost`](https://github.com/matter-labs/v2-testnet-contracts/blob/b8449bf9c819098cc8bfee0549ff5094456be51d/l1/contracts/zksync/interfaces/IMailbox.sol#L129) function, passing the gas price and gas limit from previous steps. This function returns the base cost required to send a transaction.
 

--- a/docs/dev/how-to/send-transaction-l1-l2.md
+++ b/docs/dev/how-to/send-transaction-l1-l2.md
@@ -7,7 +7,7 @@ head:
 
 # Send an L1 to L2 transaction
 
-The [zkSync Era smart contracts](https://github.com/matter-labs/era-contracts/tree/main/ethereum/contracts/zksync) allow the sender to request transactions on Ethereum L1 and pass data to zkSync Era L2.
+The [zkSync Era smart contracts](https://github.com/matter-labs/era-contracts/tree/main/l1-contracts/contracts/zksync) allow the sender to request transactions on Ethereum L1 and pass data to zkSync Era L2.
 
 ## Common use cases
 
@@ -59,7 +59,7 @@ Along with zkSync Era's built-in censorship resistance that requires multi-layer
 
 3. Apply an alias to the addresses in the request if the sender address is a contract.
 
-   If the sender is an EOA, no aliasing is required. Aliasing is implemented by the [`applyL1ToL2Alias`](https://github.com/matter-labs/era-contracts/blob/41c25aa16d182f757c3fed1463c78a81896f65e6/ethereum/contracts/vendor/AddressAliasHelper.sol#L28) Solidity function and called by the [JavaScript SDK](https://github.com/matter-labs/zksync-era/blob/48fe6e27110c1fe1a438c5375fb256890e8017b1/sdk/zksync-web3.js/src/utils.ts#L374).
+   If the sender is an EOA, no aliasing is required. Aliasing is implemented by the [`applyL1ToL2Alias`](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l1-contracts/contracts/vendor/AddressAliasHelper.sol#L28) Solidity function and called by the [JavaScript SDK](https://github.com/matter-labs/zksync-era/blob/48fe6e27110c1fe1a438c5375fb256890e8017b1/sdk/zksync-web3.js/src/utils.ts#L374).
 
    ::: code-tabs
    @tab Solidity
@@ -117,7 +117,7 @@ Along with zkSync Era's built-in censorship resistance that requires multi-layer
 
    :::
 
-5. Get the base cost by calling the [`l2TransactionBaseCost`](https://github.com/matter-labs/era-contracts/blob/3a4506522aaef81485d8abb96f5a6394bd2ba69e/ethereum/contracts/zksync/interfaces/IMailbox.sol#L130) function with:
+5. Get the base cost by calling the [`l2TransactionBaseCost`](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l1-contracts/contracts/zksync/interfaces/IMailbox.sol#L131) function with:
 
    - The gas price returned at step 2 as `_gasPrice`.
    - The gas value returned at step 3 as `_l2GasLimit`.
@@ -169,7 +169,7 @@ Along with zkSync Era's built-in censorship resistance that requires multi-layer
    }
    ```
 
-7. Send the transaction, including the gas price and base cost in the value parameters, by calling the [`requestL2Transaction`](https://github.com/matter-labs/era-contracts/blob/3a4506522aaef81485d8abb96f5a6394bd2ba69e/ethereum/contracts/zksync/interfaces/IMailbox.sol#L120) function.
+7. Send the transaction, including the gas price and base cost in the value parameters, by calling the [`requestL2Transaction`](https://github.com/matter-labs/era-contracts/blob/87cd8d7b0f8c02e9672c0603a821641a566b5dd8/l1-contracts/contracts/zksync/interfaces/IMailbox.sol#L121) function.
 
    Include the gas limit value from step 3 as `_l2GasLimit` and the `REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT` constant as `_l2GasPerPubdataByteLimit`.
 

--- a/docs/reference/concepts/bridging-asset.md
+++ b/docs/reference/concepts/bridging-asset.md
@@ -185,10 +185,10 @@ On the testnet environment, we automatically finalize all withdrawals, i.e., for
 
 To build a custom bridge, create a regular Solidity contract which extends the correct interface for the layer. The interfaces provide access to the zkSync Era SDK deposit and withdraw implementations.
 
-- L1: [IL1Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/ethereum/contracts/bridge/interfaces/IL1Bridge.sol)
+- L1: [IL1Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/bridge/interfaces/IL1Bridge.sol)
 
-  For more information, check out our example [L1 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/ethereum/contracts/bridge/L1ERC20Bridge.sol).
+  For more information, check out our example [L1 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/bridge/L1ERC20Bridge.sol).
 
-- L2: [L2ERC20Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/zksync/contracts/bridge/L2ERC20Bridge.sol)
+- L2: [L2ERC20Bridge.sol](https://github.com/matter-labs/era-contracts/blob/main/l2-contracts/contracts/bridge/L2ERC20Bridge.sol)
 
-  For more information, check out our example [L2 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/zksync/contracts/bridge/L2ERC20Bridge.sol).
+  For more information, check out our example [L2 custom bridge implementation](https://github.com/matter-labs/era-contracts/blob/main/l2-contracts/contracts/bridge/L2ERC20Bridge.sol).

--- a/docs/reference/concepts/fee-model.md
+++ b/docs/reference/concepts/fee-model.md
@@ -63,7 +63,7 @@ Because the signature is unavailable prior to the transaction taking place, an i
 
 In the case of a custom account with multiple signers, the account may wish to simulate signature validation for all the provided signers.
 
-See the [DefaultAccount code](https://github.com/matter-labs/era-system-contracts/blob/main/contracts/DefaultAccount.sol) for more information.
+See the [DefaultAccount code](https://github.com/matter-labs/era-contracts/blob/main/system-contracts/contracts/DefaultAccount.sol) for more information.
 
 ### Account abstraction considerations
 


### PR DESCRIPTION
# What :computer: 

- updated `era-contracts` and `era-system-contracts` links to reflect contract repo merge changes:
  - https://github.com/matter-labs/era-contracts/pull/98

# Why :hand:
- some of the links in the docs were broken due to the system contract repo merge