### PR TITLE
add learnweb3 faucets (zkSync and L1 for goerli/sepolia)

### DIFF
--- a/docs/reference/troubleshooting/faq.md
+++ b/docs/reference/troubleshooting/faq.md
@@ -151,6 +151,10 @@ To access the testnet funds (Sepolia or Goerli ETH) you can use one of the follo
 
 - [Chainstack's testnet faucet](https://faucet.chainstack.com/zksync-testnet-faucet)
 
+- LearnWeb3's [zkSync Goerli Faucet](https://learnweb3.io/faucets/zksync_goerli), [zkSync Sepolia Faucet](https://learnweb3.io/faucets/zksync_sepolia)
+
+- LearnWeb3's [Ethereum Goerli Faucet](https://learnweb3.io/faucets/goerli), [Ethereum Sepolia Faucet](https://learnweb3.io/faucets/sepolia)
+
 - [QuickNode] [Sepolia faucet](https://faucet.quicknode.com/ethereum/sepolia), [Goerli faucet](https://faucet.quicknode.com/ethereum/goerli)
 
 - Alchemy [Sepolia faucet](https://sepoliafaucet.com/), [Goerli faucet](https://goerlifaucet.com/)


### PR DESCRIPTION
# What :computer: 
* Add zkSync Goerli, zkSync Sepolia, Ethereum Goerli, and Ethereum Sepolia faucet links

# Why :hand:
- One of two faucets for zkSync testnets (other being Chainstack)
- One of 4-5 faucets for ETH L1 testnets

# Evidence :camera:
N/A

# Notes :memo:
Sorry it even took so long to add zkSync Sepolia support. We've supported the other 3 for quite some time now, it wasn't part of the docs - now we have support for zkSync Sepolia as well and would love to get it in the docs!
