### PR TITLE
fix: typo in zksAccountBalances for java sdk

### DIFF
--- a/docs/build/sdks/java/providers.md
+++ b/docs/build/sdks/java/providers.md
@@ -58,7 +58,7 @@ public class Main {
 | Name    | Description                                                                   |
 | ------- | ----------------------------------------------------------------------------- |
 | address | The user address with balances to check.                                      |
-| returns | 'ZksAccounteBalances': List of all balances where account has non-zero value. |
+| returns | 'ZksAccountBalances': List of all balances where account has non-zero value.  |
 
 ### `zksGetConfirmedTokens`
 

--- a/docs/build/sdks/java/providers.md
+++ b/docs/build/sdks/java/providers.md
@@ -55,10 +55,10 @@ public class Main {
 
 #### Inputs and outputs
 
-| Name    | Description                                                                   |
-| ------- | ----------------------------------------------------------------------------- |
-| address | The user address with balances to check.                                      |
-| returns | 'ZksAccountBalances': List of all balances where account has non-zero value.  |
+| Name    | Description                                                                  |
+| ------- | ---------------------------------------------------------------------------- |
+| address | The user address with balances to check.                                     |
+| returns | 'ZksAccountBalances': List of all balances where account has non-zero value. |
 
 ### `zksGetConfirmedTokens`
 


### PR DESCRIPTION
# What :computer: 
* Fix typo

# Why :hand:
* `zksAccountBalances` was mispelled

# Notes :memo:
* Addresses https://github.com/matter-labs/zksync-web-era-docs/pull/804 from @pekkadt04
