### PR TITLE
fix: several typos

### DIFF
--- a/cspell-zksync.txt
+++ b/cspell-zksync.txt
@@ -104,7 +104,6 @@ impls
 hdcaa
 emilluta
 zkevm
-cicruit
 Cuda
 cuda
 Ankr
@@ -117,7 +116,6 @@ Pythnet
 Pyth
 subql
 incentivized
-retreives
 Devs
 Ethersv
 satoshi
@@ -204,7 +202,6 @@ Binop
 mathbb
 Invb
 REDC
-skept
 ECADD
 ECMUL
 
@@ -282,18 +279,14 @@ Vitalik's
 Buterin's
 multisignature
 onchain
-convertion
 Keyhash
 Armeabi
 scijava
 gluk
 
-bytecode
-timeframe
 mkdir
 zksolc
 zksyncrobot
-precompiles
 vyper
 zkvyper
 undol

--- a/docs/build/quick-start/best-practices.md
+++ b/docs/build/quick-start/best-practices.md
@@ -77,7 +77,7 @@ require(gasleft() >= ((safeTxGas * 64) / 63).max(safeTxGas + 2500) + 500, "GS010
 {
     uint256 gasUsed = gasleft();
     // If the gasPrice is 0 we assume that nearly all available gas can be used (it is always more than safeTxGas)
-    // We only substract 2500 (compared to the 3000 before) to ensure that the amount passed is still higher than safeTxGas
+    // We only subtract 2500 (compared to the 3000 before) to ensure that the amount passed is still higher than safeTxGas
     success = execute(to, value, data, operation, gasPrice == 0 ? (gasleft() - 2500) : safeTxGas);
     gasUsed = gasUsed.sub(gasleft());
 

--- a/docs/build/sdks/rust/getting-started.md
+++ b/docs/build/sdks/rust/getting-started.md
@@ -75,7 +75,7 @@ l1_chain_id = 9
 Here, the trait `ZKSProvider` extended the `Provider<Http>` struct adding zkSync Era specific functionality.
 In this case, the method `.get_chainid()` comes from `ethers` while the method `get_l1_chain_id` comes from the `ZKSProvider` and hits an era-specific API.
 
-## Conecting to Ethereum layer-1
+## Connecting to Ethereum layer-1
 
 To perform operations that interact with both layers, we will also need to instantiate a provider for the Ethereum layer-1 associated with our zkSync Era blockchain.
 

--- a/docs/build/sdks/swift/accounts.md
+++ b/docs/build/sdks/swift/accounts.md
@@ -348,7 +348,7 @@ func allBalances(_ address: String) async throws -> Dictionary<String, String>
 #### Example
 
 ```swift
-try await walletL2.allBalances(addres: <ADDRESS>)
+try await walletL2.allBalances(address: <ADDRESS>)
 ```
 
 ### `Withdraw`

--- a/docs/build/tooling/hardhat/hardhat-zksync-ethers.md
+++ b/docs/build/tooling/hardhat/hardhat-zksync-ethers.md
@@ -102,7 +102,7 @@ function loadArtifact: (name: string) => Promise<ZkSyncArtifact>;
 function deployContract: (artifact: ZkSyncArtifact, constructorArguments: any[], wallet?: zk.Wallet, overrides?: ethers.Overrides, additionalFactoryDeps?: ethers.BytesLike[]) => Promise<zk.Contract>;
 ```
 
-- `provider()` - retruns a `zk.Provider` automatically connected to the selected network.
+- `provider()` - returns a `zk.Provider` automatically connected to the selected network.
 - `getWallet(privateKeyOrIndex?: string | number)` - returns `zk.Wallet` for the given private key or index. If the network is set to local and the private key is not provided, the method will return a wallet for rich accounts with the default index of `0` or the specified index. If the `accounts` object is set in the hardhat config and the private key is not specified, the method will return the wallet for the given account with the default index `0` or for the specified index.
 - `getWallets()` - returns all wallets of type `zk.Wallet`. If the network is set to local, the method will return wallets for rich accounts. If the `accounts` object is set in the hardhat config for the used network, the method will return the wallets for the provided accounts.
 - `getContractFactory(name: string, wallet?: zk.Wallet, deploymentType?: DeploymentType)` - returns a `zk.ContractFactory` for provided artifact name.

--- a/docs/build/tooling/hardhat/other-plugins.md
+++ b/docs/build/tooling/hardhat/other-plugins.md
@@ -29,7 +29,7 @@ This plugin was [updated to support zkSync Era](https://github.com/wighawag/hard
 
 Automatically generate TypeScript bindings for smart contracts.
 
-[More infomation](https://www.npmjs.com/package/@typechain/hardhat)
+[More information](https://www.npmjs.com/package/@typechain/hardhat)
 
 ### openzeppelin/hardhat-upgrades
 

--- a/docs/build/tutorials/smart-contract-development/account-abstraction/custom-aa-tutorial.md
+++ b/docs/build/tutorials/smart-contract-development/account-abstraction/custom-aa-tutorial.md
@@ -128,7 +128,7 @@ contract TwoUserMultisig is IAccount, IERC1271 {
             msg.sender == BOOTLOADER_FORMAL_ADDRESS,
             "Only bootloader can call this function"
         );
-        // Continure execution if called from the bootloader.
+        // Continue execution if called from the bootloader.
         _;
     }
 

--- a/docs/build/tutorials/tooling-guides/dia.md
+++ b/docs/build/tutorials/tooling-guides/dia.md
@@ -76,7 +76,7 @@ contract DIAOracle{
     uint128 public timestampOflatestPrice;
 
     /**
-    * @dev A function that retreives the price and the corresponding timestamp
+    * @dev A function that retrieves the price and the corresponding timestamp
     * from the DIA oracle and saves them in storage variables.
     * @param key - A string specifying the asset.
     */

--- a/docs/zk-stack/components/prover/boojum-function-check-if-satisfied.md
+++ b/docs/zk-stack/components/prover/boojum-function-check-if-satisfied.md
@@ -55,7 +55,7 @@ For each row and gate, we need several things.
 Placement is either UniqueOnRow or MultipleOnRow. UniqueOnRow means there is only one gate on the row (typically because
 the gate is larger / more complicated). MultipleOnRow means there are multiple gates within the same row (typically
 because the gate is smaller). For example, if a gate only needs 30 columns, but we have 150 columns, we could include
-five copies fo that gate in the same row.
+five copies for that gate in the same row.
 
 Next, if the placement is UniqueOnRow, we call evaluate_over_general_purpose_columns. All of the evaluations should be
 equal to zero, or we panic.

--- a/docs/zk-stack/components/prover/circuits/sha256-round-function.md
+++ b/docs/zk-stack/components/prover/circuits/sha256-round-function.md
@@ -341,7 +341,7 @@ let no_rounds_left = state.precompile_call_params.num_rounds.is_zero(cs);
 let write_result = Boolean::multi_and(cs, &[state.read_words_for_round, no_rounds_left]);
 
 let mut write_word = zero_u256;
-// some endianess magic
+// some endianness magic
 for (dst, src) in write_word
   .inner
   .iter_mut()

--- a/docs/zk-stack/components/zkEVM/precompiles.md
+++ b/docs/zk-stack/components/zkEVM/precompiles.md
@@ -165,7 +165,7 @@ function montgomeryMul(multiplicand, multiplier) -> ret {
 
 ```solidity
 /// @notice Computes the Montgomery modular inverse skipping the Montgomery reduction step.
-/// @dev The Montgomery reduction step is skept because a modification in the binary extended Euclidean algorithm is used to compute the modular inverse.
+/// @dev The Montgomery reduction step is skipped because a modification in the binary extended Euclidean algorithm is used to compute the modular inverse.
 /// @dev See the function `binaryExtendedEuclideanAlgorithm` for further details.
 /// @param a The field element in Montgomery form to compute the modular inverse of.
 /// @return invmod The result of the Montgomery modular inverse (in Montgomery form).


### PR DESCRIPTION
# What :computer: 
* Fix typos in markdown files
* Remove typos from cspell file

# Why :hand:
* For better user experience
* To ensure they don't continue in the future