### PR TITLE
Update hardhat-zksync-upgradable.md

### DIFF
--- a/docs/build/tooling/hardhat/hardhat-zksync-upgradable.md
+++ b/docs/build/tooling/hardhat/hardhat-zksync-upgradable.md
@@ -212,6 +212,15 @@ npx hardhat run SCRIPT_FILE
 - This provider is configured in the hardhat config file, by stating the RPC url of the network to connect to.
   :::
 
+### Openzeppelin Version
+
+The plugin does not work with the latest versions due to a blocker on the `@matterlab/zksync-contracts` package.The solution is to change the development dependencies to the previous version in your `package.json`.
+
+```
+ "@openzeppelin/contracts": "^4.9.5",
+ "@openzeppelin/contracts-upgradeable": "^4.9.5",
+```
+
 ### Hardhat config
 
 ```typescript


### PR DESCRIPTION
**Problem**

I was having some issues with deploying my contracts using the upgradable proxy pattern based on the latest [documentation](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-upgradable.html#upgrade-beacon-proxy) and the zksync upgradable plugin. I've recreated our set-up here using the simple sample provided in the 
[documentation](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-upgradable.html#upgrade-beacon-proxy).

Issue was recreated and solved in this repo: https://github.com/alaukiknpant/upgradable-contracts-zk


**Solution**

Mentioned in the Pull Request