### PR TITLE
feat: allow manual preview creation from forks

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,10 +1,8 @@
 name: "Deploy preview"
-on:
-  pull_request:
-  workflow_dispatch:
+"on":
+  pull_request
 jobs:
   build_and_preview:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     outputs:
       output_urls: "${{ steps.preview_deploy.outputs.urls }}"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,9 +1,10 @@
 name: "Deploy preview"
-"on":
-  pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 jobs:
   build_and_preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     outputs:
       output_urls: "${{ steps.preview_deploy.outputs.urls }}"


### PR DESCRIPTION
# What :computer: 
* Allow upstream forks to deploy preview

# Why :hand:
* So that we can have higher confidence in changes coming from forks

# Notes :memo:
* Only users with `Write` access to this repo are allowed to manually trigger a GitHub Action. And if they already have `Write` access, then they can just make a branch directly and not from a fork. The expectation is that reviewers of incoming PRs need to review code before approving the CI builds.
