### PR TITLE
fix: build preview for upstream pull requests

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,8 +1,10 @@
 name: "Deploy preview"
-"on":
-  pull_request
+on:
+  pull_request:
+  workflow_dispatch:
 jobs:
   build_and_preview:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     outputs:
       output_urls: "${{ steps.preview_deploy.outputs.urls }}"


### PR DESCRIPTION
# What :computer: 
* Allow users with `Write` access to manually trigger a deploy preview for upstream forks

# Why :hand:
* So that we can have higher confidence in changes coming from forks

# Notes :memo:
* Secrets should not be shared with upstream PRs and we require secrets for firebase deploys
