### PR TITLE
Update the public RPC endpoint from BlockPI network

### DIFF
--- a/docs/build/tooling/node-providers.md
+++ b/docs/build/tooling/node-providers.md
@@ -40,6 +40,6 @@ head:
 | Mainnet                                                                                              | Testnet                                                                                                              |
 | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | [https://mainnet.era.zksync.io](https://mainnet.era.zksync.io)                                       | [https://sepolia.era.zksync.dev](https://sepolia.era.zksync.dev)                                                     |
-| [https://zksync.drpc.org](https://zksync.drpc.org)                                                   | [https://zksync-era-testnet.blockpi.network/v1/rpc/public](https://zksync-era-testnet.blockpi.network/v1/rpc/public) |
+| [https://zksync.drpc.org](https://zksync.drpc.org)                                                   | [https://zksync-era-sepolia.blockpi.network/v1/rpc/public](https://zksync-era-sepolia.blockpi.network/v1/rpc/public) |
 | [https://zksync.meowrpc.com](https://zksync.meowrpc.com)                                             |                                                                                                                      |
 | [https://zksync-era.blockpi.network/v1/rpc/public](https://zksync-era.blockpi.network/v1/rpc/public) |                                                                                                                      |

--- a/docs/build/tooling/node-providers.md
+++ b/docs/build/tooling/node-providers.md
@@ -11,7 +11,7 @@ head:
 
 [Ankr](https://www.ankr.com/rpc/base/) provides private and public RPC endpoints for Base, powered by a globally distributed and decentralized network of nodes. They offer free and [paid plans](https://www.ankr.com/rpc/pricing/) with increased request limits.
 
-### BlockPi
+### BlockPI
 
 [BlockPI](https://blockpi.io/) is a high-quality, robust, and efficient RPC service network that provides access to Base nodes with [free and paid plans](https://docs.blockpi.io/documentations/pricing).
 


### PR DESCRIPTION
1. Update the testnet public endpoint to sepolia.
2. correct the typo "BlockPi" to "BlockPI"