### PR TITLE
Add link to corresponding page

### DIFF
--- a/docs/zk-stack/components/shared-bridges.md
+++ b/docs/zk-stack/components/shared-bridges.md
@@ -17,7 +17,7 @@ implemented.
 
 If you want to know more about Hyperchains, check this
 [blog post](https://blog.matter-labs.io/introduction-to-hyperchains-fdb33414ead7), or go through
-"Hyperchains" in our docs.
+[Hyperchains](../concepts/hyperchains-hyperscaling.md) in our docs.
 
 ## High-level design
 


### PR DESCRIPTION
# What :computer: 
* I have added a link to the corresponding page for the reader's convenience 

# Why :hand:
* Ease of use

# Evidence :camera:
in the previous version the user had to search

![image](https://github.com/matter-labs/zksync-web-era-docs/assets/67785258/db6fdc04-dce4-4448-b0ce-ee876dda0c20)

