### PR TITLE
fix: fixed link formatting for transaction format link

### DIFF
--- a/docs/zk-stack/components/zkEVM/bootloader.md
+++ b/docs/zk-stack/components/zkEVM/bootloader.md
@@ -49,8 +49,8 @@ We also ensure that transactions do not exceed the limits of the memory space al
 
 ## Transaction Types and Validation
 
-While the main transaction format is the internal []`Transaction`
-format](<https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/system-contracts/contracts/libraries/TransactionHelper.sol#L25>),
+While the main transaction format is the internal [`Transaction`
+format](https://github.com/code-423n4/2023-10-zksync/blob/ef99273a8fdb19f5912ca38ba46d6bd02071363d/code/system-contracts/contracts/libraries/TransactionHelper.sol#L25),
 it is a struct that is used to represent various kinds of transactions types. It contains a lot of `reserved` fields
 that could be used depending in the future types of transactions without need for AA to change the interfaces of their
 contracts.


### PR DESCRIPTION
# What :computer: 
* I have made a fix to link formatting error on Bootloader page.

# Why :hand:
* The Markdown file had a minor issue such as a formatting error. This has been corrected to enhance the readability and consistency of the document.

# Evidence :camera:

![Screenshot_1](https://github.com/matter-labs/zksync-web-era-docs/assets/56926590/67313211-c89d-49cb-a1a3-8aead6990371)