### PR TITLE
fix: removing npm tab for zksync-cli

### DIFF
--- a/docs/build/tutorials/how-to/send-transaction-l1-l2.md
+++ b/docs/build/tutorials/how-to/send-transaction-l1-l2.md
@@ -235,28 +235,12 @@ User needs to perform next steps:
 
 1. Run local node dockerized containers. [`Instructions how to run it`](https://github.com/matter-labs/local-setup/tree/main) or use [`zksync-cli`](https://github.com/matter-labs/zksync-cli):
 
-::: code-tabs
-@tab npx
-
 ```npx
   npx zksync-cli dev config
   // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
   // choose: BE and Portal (optional)
   npx zksync-cli dev start
 ```
-
-@tab npm
-
-```npm
-  // install zksync-cli
-  npm i -g zksync-cli
-  zksync-cli dev config
-  // choose: Dockerized node - Persistent state, includes L1 and L2 nodes
-  // choose: BE and Portal (optional)
-  zksync-cli dev start
-```
-
-:::
 
 2. In the root folder of the imported project (step 1) create `file.js` and insert there code from example below
 3. In the root folder add `.env` file with private key of wallet to use


### PR DESCRIPTION
# What :computer: 
* removed `npm` codeblock tab for zksync-cli - just `npx` left (fix requested by @JackHamer09)

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
