### PR TITLE
fix: fixing export statement being in 1 line

### DIFF
--- a/docs/zk-stack/running-a-hyperchain/locally.md
+++ b/docs/zk-stack/running-a-hyperchain/locally.md
@@ -27,7 +27,8 @@ git clone https://github.com/matter-labs/zksync-era
 2. Add `ZKSYNC_HOME` to your path (e.g. `~/.bash_profile`, `~/.zshrc` ) - don't forget to source your profile file again (or restart your terminal):
 
 ```bash
-export ZKSYNC_HOME=/path/to/zksync/repo/you/cloned export PATH=$ZKSYNC_HOME/bin:$PATH
+export ZKSYNC_HOME=/path/to/zksync/repo/you/cloned
+export PATH=$ZKSYNC_HOME/bin:$PATH
 ```
 
 3. Build latest version of zk tools by just running `zk` on the root of the project.


### PR DESCRIPTION
# What :computer: 
* Fixed export statement for path being both on 1 line

# Why :hand:
* If not people might run command wrong