### PR TITLE
Added Alpine Linux to Docker options in dependencies.md

### DIFF
--- a/docs/zk-stack/running-a-hyperchain/dependencies.md
+++ b/docs/zk-stack/running-a-hyperchain/dependencies.md
@@ -60,6 +60,9 @@ Note: currently official site proposes using Docker Desktop for Linux, which is 
 want to only have CLI tool, you need the `docker-ce` package and you can follow
 [this guide](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-20-04) for Ubuntu.
 
+Alpine Linux is known to be one of the easiest ways of running Docker. You can follow
+[this guide](https://wiki.alpinelinux.org/wiki/Docker#Installation) for installing Docker in Alpine Linux.
+
 Installing `docker` via `snap` or from the default repository can cause troubles.
 
 You need to install both `docker` and `docker-compose`.


### PR DESCRIPTION
# What :computer: 
I am very surprised Alpine Linux was not included in Docker section. I updated Docker instructions to include Alpine Linux.

# Why :hand:
Alpine Linux is widely known to be the best way to run Docker in Linux. I have used it on many occasions and its been great. 

" In 2016, Docker decided to switch the official Docker image library from Ubuntu to Alpine"
https://thenewstack.io/alpine-linux-heart-docker/

