### PR TITLE
feat: update gpu ram from 16 to 8

### DIFF
--- a/docs/zk-stack/running-a-hyperchain/locally.md
+++ b/docs/zk-stack/running-a-hyperchain/locally.md
@@ -145,7 +145,7 @@ There are two options for running the Boojum prover: in GPU, or in CPU.
 
 The docker compose file assumes you will be running all components in the same machine. The current minimum requirements for a low TPS scenario are:
 
-- 16 GB VRAM NVIDIA GPU
+- 8 GB VRAM NVIDIA GPU
 - 16 Core CPU
 - 64 GB of RAM
 - 300 GB of Disk Space (SSD preferred)


### PR DESCRIPTION
# What :computer: 
* Update GPU RAM requirements for prover from 16Gb -> 6Gb

# Why :hand:
* Because @robik75 is kick ass and [lowered](https://github.com/matter-labs/era-shivini/pull/27) GPU RAM requirements from 16Gb -> 6Gb 