### PR TITLE
fix: the word "make" was spelled incorrect

### DIFF
--- a/docs/build/tutorials/smart-contract-development/account-abstraction/custom-aa-tutorial.md
+++ b/docs/build/tutorials/smart-contract-development/account-abstraction/custom-aa-tutorial.md
@@ -66,7 +66,7 @@ yarn add -D @matterlabs/zksync-contracts @openzeppelin/contracts@4.9.5
 
 ::: warning
 
-This project does not use the latest version available of `@openzeppelin/contracts`. Mae sure you install the specific version mentioned above.
+This project does not use the latest version available of `@openzeppelin/contracts`. Make sure you install the specific version mentioned above.
 
 :::
 

--- a/docs/build/tutorials/smart-contract-development/account-abstraction/daily-spend-limit.md
+++ b/docs/build/tutorials/smart-contract-development/account-abstraction/daily-spend-limit.md
@@ -64,7 +64,7 @@ yarn add -D @matterlabs/zksync-contracts @openzeppelin/contracts@4.9.5
 ```
 
 ::: warning
-This project does not use the latest version available of `@openzeppelin/contracts`. Mae sure you install the specific version mentioned above.
+This project does not use the latest version available of `@openzeppelin/contracts`. Make sure you install the specific version mentioned above.
 :::
 
 5. Include the `isSystem: true` setting in the `zksolc` section of the `hardhat.config.ts` configuration file to allow interaction with system contracts:


### PR DESCRIPTION
# What :computer: 
Fixed the word `mae` to the correctly spelled `make`

# Why :hand:
cuz spelling gud

# Evidence :camera:
see spelling