### PR TITLE
feat: add Cyfrin Updraft security curriculum for security education

### DIFF
--- a/cspell-zksync.txt
+++ b/cspell-zksync.txt
@@ -66,6 +66,7 @@ Arweave
 Streamr
 dutterbutter
 zeek
+Cyfrin
 
 // Used libraries
 numberish

--- a/docs/build/developer-reference/contract-deployment.md
+++ b/docs/build/developer-reference/contract-deployment.md
@@ -72,6 +72,7 @@ The process of auditing a smart contract should be carried out by experts who ha
 
 For detailed information on smart contract vulnerabilities and security best practices, refer to the following resources:
 
+- [Cyfrin Updraft Security & Auditing Curriculum](https://updraft.cyfrin.io/courses/security).
 - [Consensys smart contract best practices](https://consensys.github.io/smart-contract-best-practices/).
 - [Solidity docs security considerations](https://docs.soliditylang.org/en/latest/security-considerations.html).
 - [Security considerations and best practices on zkSync](../quick-start/best-practices.md)


### PR DESCRIPTION
# What :computer: 
* Added cyfrin updraft security curriculum

# Why :hand:
* It is the most extensive, up to date, and thorough, security and auditing curriculum ever created

