### PR TITLE
Using correct link for testnet sepolia api docs.

### DIFF
--- a/docs/build/tooling/block-explorer/block-explorer-api.md
+++ b/docs/build/tooling/block-explorer/block-explorer-api.md
@@ -19,7 +19,7 @@ The following modules are supported:
 - [Logs](https://block-explorer-api.mainnet.zksync.io/docs#/Logs%20API)
 - [Block](https://block-explorer-api.mainnet.zksync.io/docs#/Block%20API)
 
-Check out the API documentation [API docs on Mainnet](https://block-explorer-api.mainnet.zksync.io/docs) | [API docs on Testnet](https://block-explorer-api.testnets.zksync.dev/docs)
+Check out the API documentation [API docs on Mainnet](https://block-explorer-api.mainnet.zksync.io/docs) | [API docs on Testnet](https://block-explorer-api.sepolia.zksync.dev/docs)
 
 :::note Note
 

--- a/docs/build/tooling/block-explorer/getting-started.md
+++ b/docs/build/tooling/block-explorer/getting-started.md
@@ -27,7 +27,7 @@ The following modules are supported:
 - [Logs](https://block-explorer-api.mainnet.zksync.io/docs#/Logs%20API)
 - [Block](https://block-explorer-api.mainnet.zksync.io/docs#/Block%20API)
 
-Check out the API documentation [API docs on Mainnet](https://block-explorer-api.mainnet.zksync.io/docs) | [API docs on Testnet](https://block-explorer-api.testnets.zksync.dev/docs)
+Check out the API documentation [API docs on Mainnet](https://block-explorer-api.mainnet.zksync.io/docs) | [API docs on Testnet](https://block-explorer-api.sepolia.zksync.dev/docs)
 
 :::note Note
 


### PR DESCRIPTION
# What :computer: 
* The documentation for the explorer was using a dead link for the testnet api link. This PR changes that link to one that seems to be the right one.

# Why :hand:
* It is confusing having a dead link on the testnet api. My first impression was that the public api was not available por testnet. Which was weird. I found the real link inspecting the behavior of the production version of the testnet explorer.

# Evidence :camera:
Old link:
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/5994653/78ba409d-87bf-4301-a100-9e0092a6a8d0)


New link:
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/5994653/68728790-c22a-4616-8463-bad246d1fdf0)
