### PR TITLE
Fixing broken link to Pyth docs

### DIFF
--- a/docs/build/tooling/oracles.md
+++ b/docs/build/tooling/oracles.md
@@ -25,7 +25,7 @@ Welcome to the Oracles page, a comprehensive hub dedicated to interacting with o
 
 ### Pyth
 
-[Pythnet](https://docs.pyth.network/documentation/pythnet-price-feeds) price feeds use a "pull" price update model, where users are responsible for posting price updates on-chain when needed. Checkout the usage guide to get started today!
+[Pythnet](https://docs.pyth.network/price-feeds) price feeds use a "pull" price update model, where users are responsible for posting price updates on-chain when needed. Checkout the usage guide to get started today!
 
 ### Usage guides
 


### PR DESCRIPTION
# What :computer: 
* The current link to the Pyth docs is broken, I updated it to https://docs.pyth.network/price-feeds

# Evidence :camera:

<img width="608" alt="image" src="https://github.com/matter-labs/zksync-web-era-docs/assets/152931880/1e76d037-bac7-4054-a963-8975706d27bf">