### PR TITLE
chore: add --tag param to the hardhat-zksync-node command list

### DIFF
--- a/docs/build/tooling/hardhat/hardhat-zksync-node.md
+++ b/docs/build/tooling/hardhat/hardhat-zksync-node.md
@@ -80,6 +80,7 @@ This command runs a local zkSync In-memory node by initiating a JSON-RPC server.
 - `--fork` - Starts a local network that is a fork of another network. Accepted values are: testnet, mainnet, or a specific URL.
 - `--fork-block-number` - Specifies the block height at which to fork.
 - `--replay-tx` - Transaction hash to replay.
+- `--tag` - Specifies the zkSync era test node release to be used
 
 ::: warning Parameter Restrictions
 


### PR DESCRIPTION
# What :computer: 
* Add `--tag` param to the hardhat-zksync-node command list

# Why :hand:
*  Fill the gap in our docs for hardhat-zksync-node where we don't clarify that `--tag` exists so user can specify era test node release.